### PR TITLE
feat: api for recording actions

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -9,7 +9,7 @@ on:
 
 name: prerelease
 jobs:
-  release-please:
+  prerelease:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
           CI: true
       - name: Publish to NPM
         run: |
-          yarn version --new-version ${{ github.event.inputs.tag }}
+          yarn version --no-git-tag-version --new-version ${{ github.event.inputs.tag }}
 
           npm publish --access=public --tag nightly
         env:

--- a/src/host-api/api.ts
+++ b/src/host-api/api.ts
@@ -26,6 +26,7 @@ export interface ModuleToHostEventsV0 {
 	'send-osc': (msg: SendOscMessage) => never
 	parseVariablesInString: (msg: ParseVariablesInStringMessage) => ParseVariablesInStringResponseMessage
 	upgradedItems: (msg: UpgradedDataResponseMessage) => void
+	recordAction: (mgs: RecordActionMessage) => never
 }
 
 export interface HostToModuleEventsV0 {
@@ -39,6 +40,7 @@ export interface HostToModuleEventsV0 {
 	handleHttpRequest: (msg: HandleHttpRequestMessage) => HandleHttpRequestResponseMessage
 	learnAction: (msg: LearnActionMessage) => LearnActionResponseMessage
 	learnFeedback: (msg: LearnFeedbackMessage) => LearnFeedbackResponseMessage
+	startStopRecordActions: (msg: StartStopRecordActionsMessage) => void
 }
 
 export type EncodeIsVisible<T extends SomeCompanionInputField> = Omit<T, 'isVisible'> & {
@@ -56,6 +58,7 @@ export interface InitMessage {
 }
 export interface InitResponseMessage {
 	hasHttpHandler: boolean
+	hasRecordActionsHandler: boolean
 	newUpgradeIndex: number
 
 	updatedConfig: unknown | undefined
@@ -243,4 +246,15 @@ export interface LearnFeedbackMessage {
 }
 export interface LearnFeedbackResponseMessage {
 	options: CompanionOptionValues | undefined
+}
+
+export interface StartStopRecordActionsMessage {
+	recording: boolean
+	controlId: string
+}
+
+export interface RecordActionMessage {
+	uniquenessId: string | null
+	actionId: string
+	options: CompanionOptionValues
 }

--- a/src/host-api/api.ts
+++ b/src/host-api/api.ts
@@ -250,7 +250,6 @@ export interface LearnFeedbackResponseMessage {
 
 export interface StartStopRecordActionsMessage {
 	recording: boolean
-	controlId: string
 }
 
 export interface RecordActionMessage {

--- a/src/module-api/base.ts
+++ b/src/module-api/base.ts
@@ -391,7 +391,7 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 
 		this.#recordingActions = msg.recording
 
-		this.handleStartStopRecordActions(msg.controlId)
+		this.handleStartStopRecordActions(this.#recordingActions, msg.controlId)
 	}
 
 	/**
@@ -432,9 +432,10 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 
 	/**
 	 * Handle request from Companion to start/stop recording actions
+	 * @param isRecording whether recording is now running
 	 * @param controlId control actions are being recorded for
 	 */
-	handleStartStopRecordActions?(controlId: string): boolean
+	handleStartStopRecordActions?(isRecording: boolean, controlId: string): void
 
 	/**
 	 * Set the action definitions for this instance

--- a/src/module-api/base.ts
+++ b/src/module-api/base.ts
@@ -391,7 +391,7 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 
 		this.#recordingActions = msg.recording
 
-		this.handleStartStopRecordActions(this.#recordingActions, msg.controlId)
+		this.handleStartStopRecordActions(this.#recordingActions)
 	}
 
 	/**
@@ -433,9 +433,8 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 	/**
 	 * Handle request from Companion to start/stop recording actions
 	 * @param isRecording whether recording is now running
-	 * @param controlId control actions are being recorded for
 	 */
-	handleStartStopRecordActions?(isRecording: boolean, controlId: string): void
+	handleStartStopRecordActions?(isRecording: boolean): void
 
 	/**
 	 * Set the action definitions for this instance


### PR DESCRIPTION
public api portions:

```ts
	/**
	 * Handle request from Companion to start/stop recording actions
	 * @param isRecording whether recording is now running
	 */
	handleStartStopRecordActions?(isRecording: boolean): void

	/**
	 * Add an action to the current recording session
	 * @param action The action to be added to the recording session
	 * @param uniquenessId A unique id for the action being recorded. This should be different for each action, but by passing the same as a previous call will replace the previous value
	 */
	recordAction(action: Omit<CompanionActionInfo, 'id' | 'controlId'>, uniquenessId?: string): void
```