### PR TITLE
feat: modules set custom variables

### DIFF
--- a/src/host-api/api.ts
+++ b/src/host-api/api.ts
@@ -5,13 +5,15 @@
  * This will allow for cleaner and more stable apis which can both evolve at different rates
  */
 
-import { CompanionFeedbackButtonStyleResult } from '../module-api/feedback.js'
+import { CompanionFeedbackButtonStyleResult, SomeCompanionFeedbackInputField } from '../module-api/feedback.js'
 import { OSCSomeArguments } from '../common/osc.js'
 import { SomeCompanionConfigField } from '../module-api/config.js'
 import { LogLevel, InstanceStatus } from '../module-api/enums.js'
-import { SomeCompanionInputField, InputValue, CompanionOptionValues } from '../module-api/input.js'
+import { InputValue, CompanionOptionValues, CompanionInputFieldBase } from '../module-api/input.js'
 import { SomeCompanionPresetDefinition } from '../module-api/preset.js'
 import { CompanionHTTPRequest, CompanionHTTPResponse } from '../module-api/http.js'
+import { SomeCompanionActionInputField } from '../module-api/action.js'
+import { CompanionVariableValue } from '../module-api/variable.js'
 
 export interface ModuleToHostEventsV0 {
 	'log-message': (msg: LogMessageMessage) => never
@@ -26,7 +28,8 @@ export interface ModuleToHostEventsV0 {
 	'send-osc': (msg: SendOscMessage) => never
 	parseVariablesInString: (msg: ParseVariablesInStringMessage) => ParseVariablesInStringResponseMessage
 	upgradedItems: (msg: UpgradedDataResponseMessage) => void
-	recordAction: (mgs: RecordActionMessage) => never
+	recordAction: (msg: RecordActionMessage) => never
+	setCustomVariable: (msg: SetCustomVariableMessage) => never
 }
 
 export interface HostToModuleEventsV0 {
@@ -43,7 +46,7 @@ export interface HostToModuleEventsV0 {
 	startStopRecordActions: (msg: StartStopRecordActionsMessage) => void
 }
 
-export type EncodeIsVisible<T extends SomeCompanionInputField> = Omit<T, 'isVisible'> & {
+export type EncodeIsVisible<T extends CompanionInputFieldBase> = Omit<T, 'isVisible'> & {
 	isVisibleFn?: string
 }
 
@@ -86,14 +89,12 @@ export interface SetStatusMessage {
 	message: string | null
 }
 
-export type SomeEncodedCompanionInputField = EncodeIsVisible<SomeCompanionInputField>
-
 export interface SetActionDefinitionsMessage {
 	actions: Array<{
 		id: string
 		name: string
 		description?: string
-		options: SomeEncodedCompanionInputField[] // TODO module-lib - versioned types?
+		options: EncodeIsVisible<SomeCompanionActionInputField>[] // TODO module-lib - versioned types?
 		hasLearn: boolean
 	}>
 }
@@ -103,7 +104,7 @@ export interface SetFeedbackDefinitionsMessage {
 		id: string
 		name: string
 		description?: string
-		options: SomeEncodedCompanionInputField[] // TODO module-lib - versioned types?
+		options: EncodeIsVisible<SomeCompanionFeedbackInputField>[] // TODO module-lib - versioned types?
 		type: 'boolean' | 'advanced'
 		defaultStyle?: Partial<CompanionFeedbackButtonStyleResult>
 		hasLearn: boolean
@@ -256,4 +257,9 @@ export interface RecordActionMessage {
 	uniquenessId: string | null
 	actionId: string
 	options: CompanionOptionValues
+}
+
+export interface SetCustomVariableMessage {
+	customVariableId: string
+	value: CompanionVariableValue
 }

--- a/src/internal/base.ts
+++ b/src/internal/base.ts
@@ -2,7 +2,7 @@ import * as SocketIOClient from 'socket.io-client'
 import { CompanionStaticUpgradeScript } from '../module-api/upgrade'
 import { EncodeIsVisible } from '../host-api/api.js'
 import { ResultCallback } from '../host-api/versions.js'
-import { SomeCompanionInputField } from '../module-api/input'
+import { CompanionInputFieldBase } from '../module-api/input'
 
 /**
  * Signature for the handler functions
@@ -45,7 +45,7 @@ export function listenToEvents<T extends object>(socket: SocketIOClient.Socket<T
 	}
 }
 
-export function serializeIsVisibleFn<T extends SomeCompanionInputField>(options: T[]): EncodeIsVisible<T>[] {
+export function serializeIsVisibleFn<T extends CompanionInputFieldBase>(options: T[]): EncodeIsVisible<T>[] {
 	return options.map((option) => {
 		if ('isVisible' in option) {
 			if (typeof option.isVisible === 'function') {

--- a/src/module-api/action.ts
+++ b/src/module-api/action.ts
@@ -1,4 +1,24 @@
-import { SomeCompanionInputField, CompanionOptionValues } from './input.js'
+import {
+	CompanionOptionValues,
+	CompanionInputFieldCheckbox,
+	CompanionInputFieldColor,
+	CompanionInputFieldDropdown,
+	CompanionInputFieldMultiDropdown,
+	CompanionInputFieldNumber,
+	CompanionInputFieldStaticText,
+	CompanionInputFieldTextInput,
+	CompanionInputFieldCustomVariable,
+} from './input.js'
+
+export type SomeCompanionActionInputField =
+	| CompanionInputFieldStaticText
+	| CompanionInputFieldColor
+	| CompanionInputFieldTextInput
+	| CompanionInputFieldDropdown
+	| CompanionInputFieldMultiDropdown
+	| CompanionInputFieldNumber
+	| CompanionInputFieldCheckbox
+	| CompanionInputFieldCustomVariable
 
 /**
  * The definition of an action
@@ -9,7 +29,7 @@ export interface CompanionActionDefinition {
 	/** Additional description of the action */
 	description?: string
 	/** The input fields for the action */
-	options: SomeCompanionInputField[]
+	options: SomeCompanionActionInputField[]
 	/** Called to execute the action */
 	callback: (action: CompanionActionEvent) => Promise<void> | void
 	/**

--- a/src/module-api/base.ts
+++ b/src/module-api/base.ts
@@ -793,6 +793,20 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 	}
 
 	/**
+	 * Experimental: This method may change without notice. Do not use!
+	 * Set the value of a custom variable
+	 * @param variableId
+	 * @param value
+	 * @returns Promise which resolves upon success, or rejects if the variable no longer exists
+	 */
+	setCustomVariableValue(variableId: string, value: CompanionVariableValue): void {
+		this._socketEmitNoCb('setCustomVariable', {
+			customVariableId: variableId,
+			value,
+		})
+	}
+
+	/**
 	 * Send an osc message from the system osc sender
 	 * @param host destination ip address
 	 * @param port destination port number

--- a/src/module-api/config.ts
+++ b/src/module-api/config.ts
@@ -1,4 +1,13 @@
-import { CompanionInputFieldBase, SomeCompanionInputField } from './input.js'
+import {
+	CompanionInputFieldBase,
+	CompanionInputFieldCheckbox,
+	CompanionInputFieldColor,
+	CompanionInputFieldDropdown,
+	CompanionInputFieldMultiDropdown,
+	CompanionInputFieldNumber,
+	CompanionInputFieldStaticText,
+	CompanionInputFieldTextInput,
+} from './input.js'
 
 /**
  * A configuration input field
@@ -10,4 +19,13 @@ export interface CompanionConfigField extends CompanionInputFieldBase {
 /**
  * Some configuration input field
  */
-export type SomeCompanionConfigField = SomeCompanionInputField & CompanionConfigField
+export type SomeCompanionConfigField = (
+	| CompanionInputFieldStaticText
+	| CompanionInputFieldColor
+	| CompanionInputFieldTextInput
+	| CompanionInputFieldDropdown
+	| CompanionInputFieldMultiDropdown
+	| CompanionInputFieldNumber
+	| CompanionInputFieldCheckbox
+) &
+	CompanionConfigField

--- a/src/module-api/feedback.ts
+++ b/src/module-api/feedback.ts
@@ -1,5 +1,23 @@
-import { SomeCompanionInputField, CompanionOptionValues } from './input.js'
+import {
+	CompanionOptionValues,
+	CompanionInputFieldStaticText,
+	CompanionInputFieldCheckbox,
+	CompanionInputFieldColor,
+	CompanionInputFieldDropdown,
+	CompanionInputFieldMultiDropdown,
+	CompanionInputFieldNumber,
+	CompanionInputFieldTextInput,
+} from './input.js'
 import { CompanionAdditionalStyleProps, CompanionRequiredStyleProps } from './style.js'
+
+export type SomeCompanionFeedbackInputField =
+	| CompanionInputFieldStaticText
+	| CompanionInputFieldColor
+	| CompanionInputFieldTextInput
+	| CompanionInputFieldDropdown
+	| CompanionInputFieldMultiDropdown
+	| CompanionInputFieldNumber
+	| CompanionInputFieldCheckbox
 
 /**
  * Basic information about an instance of an feedback
@@ -68,7 +86,7 @@ export interface CompanionFeedbackDefinitionBase {
 	/** Additional description of the feedback */
 	description?: string
 	/** The input fields for the feedback */
-	options: SomeCompanionInputField[]
+	options: SomeCompanionFeedbackInputField[]
 	/**
 	 * Called to report the existence of an feedback
 	 * Useful to ensure necessary data is loaded

--- a/src/module-api/input.ts
+++ b/src/module-api/input.ts
@@ -4,15 +4,6 @@ export interface CompanionOptionValues {
 	[key: string]: InputValue | undefined
 }
 
-export type SomeCompanionInputField =
-	| CompanionInputFieldStaticText
-	| CompanionInputFieldColor
-	| CompanionInputFieldTextInput
-	| CompanionInputFieldDropdown
-	| CompanionInputFieldMultiDropdown
-	| CompanionInputFieldNumber
-	| CompanionInputFieldCheckbox
-
 /**
  * The common properties for an input field
  */
@@ -20,7 +11,15 @@ export interface CompanionInputFieldBase {
 	/** The unique id of this input field within the input group */
 	id: string
 	/** The type of this input field */
-	type: 'static-text' | 'textinput' | 'dropdown' | 'multidropdown' | 'colorpicker' | 'number' | 'checkbox'
+	type:
+		| 'static-text'
+		| 'textinput'
+		| 'dropdown'
+		| 'multidropdown'
+		| 'colorpicker'
+		| 'number'
+		| 'checkbox'
+		| 'custom-variable'
 	/** The label of the field */
 	label: string
 	/** A hover tooltip for this field */
@@ -265,4 +264,22 @@ export interface CompanionInputFieldNumber extends CompanionInputFieldBase {
 
 	/** Whether to show a slider for the input */
 	range?: boolean
+}
+
+/**
+ * A custom variable picker input
+ *
+ * Available for actions
+ *
+ * Example:
+ * ```js
+ * {
+ * 	id: 'destination',
+ * 	type: 'custom-variable',
+ * 	label: 'Save result to variable',
+ * }
+ * ```
+ */
+export interface CompanionInputFieldCustomVariable extends CompanionInputFieldBase {
+	type: 'custom-variable'
 }


### PR DESCRIPTION
Sometimes it is appropriate for modules to be able to set a custom-variable as part of an action.
This proposal is to allow for setting custom-variables, but is intended to only support doing so from an action. It technically will be possible at other times, but the module will need to know the id/name of a custom variable to write to, which wont be exposed directly.

The generic-http modules gives a good example of this, where you can store the result of the request into a variable:
![image](https://user-images.githubusercontent.com/1327476/191127545-2294cfd2-a4bd-4e78-a176-53a99dfbcca0.png)

I think this could make sense for other modules too. Particularly those which interface with some cloud service, eg
* spotify-remote: check if a specified trackId is playable
* some video encoder: grab a frame from input X (when doing so is expensive and requires polling)

Some of these could be achieved with more variables in the module, but some of them would require creating temporary 'scratch space' variables that will then need to be copied to custom-variables before using the value.

---------

I am wondering if a better flow would be for action definitions to have a property `producesResult`, and then when it is executed, the return value is written to a variable.
This would keep the custom-variable handling inside of core, but does give companion itself more logic/work to handle this, and makes the typescript types a little more confusing.

```ts
export interface CompanionActionDefinition {
	/** Called to execute the action */
	callback: (action: CompanionActionEvent) => Promise<CompanionVariableValue | undefined> | CompanionVariableValue | undefined
    /** If the callback produces a result that can be saved in a variable */
    producesResult?: boolean

    ......
}
```
