### PR TITLE
feat: cleanup for dropping legacy modules

### DIFF
--- a/src/internal/actions.ts
+++ b/src/internal/actions.ts
@@ -199,16 +199,6 @@ export class ActionManager {
 		this.#setActionDefinitions({ actions: hostActions })
 	}
 
-	/** @deprecated */
-	_getAllActions(): Pick<ActionInstance, 'id' | 'actionId' | 'controlId' | 'options'>[] {
-		return Array.from(this.#actionInstances.values()).map((act) => ({
-			id: act.id,
-			actionId: act.actionId,
-			controlId: act.controlId,
-			options: act.options,
-		}))
-	}
-
 	subscribeActions(actionIds: string[]): void {
 		let actions = Array.from(this.#actionInstances.values())
 

--- a/src/internal/feedback.ts
+++ b/src/internal/feedback.ts
@@ -420,16 +420,6 @@ export class FeedbackManager {
 		}
 	}
 
-	/** @deprecated */
-	_getAllFeedbacks(): Pick<FeedbackInstance, 'id' | 'feedbackId' | 'controlId' | 'options'>[] {
-		return Array.from(this.#feedbackInstances.values()).map((fb) => ({
-			id: fb.id,
-			feedbackId: fb.feedbackId,
-			controlId: fb.controlId,
-			options: fb.options,
-		}))
-	}
-
 	subscribeFeedbacks(feedbackIds: string[]): void {
 		let feedbacks = Array.from(this.#feedbackInstances.values())
 

--- a/src/module-api/base.ts
+++ b/src/module-api/base.ts
@@ -3,9 +3,7 @@ import type { CompanionFeedbackDefinitions } from './feedback.js'
 import type { CompanionPresetDefinitions } from './preset.js'
 import type { InstanceStatus, LogLevel } from './enums.js'
 import type {
-	ActionInstance,
 	ExecuteActionMessage,
-	FeedbackInstance,
 	GetConfigFieldsMessage,
 	GetConfigFieldsResponseMessage,
 	HandleHttpRequestMessage,
@@ -535,11 +533,6 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 		this.#feedbackManager.checkFeedbacksById(feedbackIds)
 	}
 
-	/** @deprecated */
-	_getAllActions(): Pick<ActionInstance, 'id' | 'actionId' | 'controlId' | 'options'>[] {
-		return this.#actionManager._getAllActions()
-	}
-
 	/**
 	 * Call subscribe on all currently known placed actions.
 	 * It can be useful to trigger this upon establishing a connection, to ensure all data is loaded.
@@ -555,11 +548,6 @@ export abstract class InstanceBase<TConfig> implements InstanceBaseShared<TConfi
 	 */
 	unsubscribeActions(...actionIds: string[]): void {
 		this.#actionManager.unsubscribeActions(actionIds)
-	}
-
-	/** @deprecated */
-	_getAllFeedbacks(): Pick<FeedbackInstance, 'id' | 'feedbackId' | 'controlId' | 'options'>[] {
-		return this.#feedbackManager._getAllFeedbacks()
 	}
 
 	/**


### PR DESCRIPTION
Cleans up some 'junk' that was added for compatibility reasons, but we don't want updated modules to depend upon