### PR TITLE
fix: Add undefined checks to upgrade for missing options

### DIFF
--- a/src/internal/upgrade.ts
+++ b/src/internal/upgrade.ts
@@ -129,7 +129,7 @@ export function runThroughUpgradeScripts(
 									controlId: inst.controlId,
 
 									feedbackId: inst.feedbackId,
-									options: clone(inst.options),
+									options: clone(inst.options !== undefined ? clone(inst.options) : {}),
 									// TODO - style?
 								})
 							}

--- a/src/internal/upgrade.ts
+++ b/src/internal/upgrade.ts
@@ -114,7 +114,7 @@ export function runThroughUpgradeScripts(
 									controlId: inst.controlId,
 
 									actionId: inst.actionId,
-									options: clone(inst.options !== undefined ? clone(inst.options) : {}),
+									options: inst.options !== undefined ? clone(inst.options) : {},
 								})
 							}
 						})
@@ -129,7 +129,7 @@ export function runThroughUpgradeScripts(
 									controlId: inst.controlId,
 
 									feedbackId: inst.feedbackId,
-									options: clone(inst.options !== undefined ? clone(inst.options) : {}),
+									options: inst.options !== undefined ? clone(inst.options) : {},
 									// TODO - style?
 								})
 							}

--- a/src/internal/upgrade.ts
+++ b/src/internal/upgrade.ts
@@ -114,7 +114,7 @@ export function runThroughUpgradeScripts(
 									controlId: inst.controlId,
 
 									actionId: inst.actionId,
-									options: clone(inst.options),
+									options: clone(inst.options !== undefined ? clone(inst.options) : {}),
 								})
 							}
 						})


### PR DESCRIPTION
Configs that are missing options for actions or feedbacks cause the module instance to crash during upgrades. See issue #47 

Added checks for undefined to avoid trying to clone an undefined property.