### PR TITLE
Stronger typings and simpler variable parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 		"nanoid": "^3.3.4",
 		"p-queue": "^6.6.2",
 		"p-timeout": "^4.1.0",
-		"tslib": "^2.6.2"
+		"tslib": "^2.6.2",
+		"type-fest": "^4.15.0"
 	},
 	"devDependencies": {
 		"@companion-module/tools": "^1.5.0",

--- a/src/internal/strict-options.ts
+++ b/src/internal/strict-options.ts
@@ -1,0 +1,72 @@
+import type { ConditionalKeys } from 'type-fest'
+import type { CompanionOptionValues, CompanionActionContext } from '../module-api/index.js'
+import type { CompanionCommonCallbackContext, StrictOptions, StrictOptionsObject } from '../module-api/common.js'
+
+export class StrictOptionsImpl<TOptions> implements StrictOptions<TOptions> {
+	readonly #options: any
+	readonly #context: CompanionCommonCallbackContext
+	readonly #fields: StrictOptionsObject<TOptions, any>
+
+	constructor(
+		options: CompanionOptionValues,
+		context: CompanionActionContext,
+		fields: StrictOptionsObject<TOptions, any>
+	) {
+		this.#options = options
+		this.#context = context
+		this.#fields = fields
+	}
+
+	getRawJson(): any {
+		return { ...this.#options }
+	}
+	getRaw<Key extends keyof TOptions>(fieldName: Key): any {
+		// TODO - should this populate defaults?
+		return this.#options[fieldName]
+	}
+
+	getPlainString<Key extends ConditionalKeys<TOptions, string>>(fieldName: Key): TOptions[Key] {
+		const fieldSpec = this.#fields[fieldName]
+		const defaultValue = fieldSpec && 'default' in fieldSpec ? fieldSpec.default : undefined
+
+		const rawValue = this.#options[fieldName]
+		if (defaultValue !== undefined && rawValue === undefined) return String(defaultValue) as any
+
+		return String(rawValue) as any
+	}
+
+	getPlainNumber<Key extends ConditionalKeys<TOptions, number>>(fieldName: Key): TOptions[Key] {
+		const fieldSpec = this.#fields[fieldName]
+		const defaultValue = fieldSpec && 'default' in fieldSpec ? fieldSpec.default : undefined
+
+		const rawValue = this.#options[fieldName]
+		if (defaultValue !== undefined && rawValue === undefined) return Number(defaultValue) as any
+
+		const value = Number(rawValue)
+		if (isNaN(value)) {
+			throw new Error(`Invalid option '${String(fieldName)}'`)
+		}
+		return value as any
+	}
+
+	getPlainBoolean<Key extends ConditionalKeys<TOptions, boolean>>(fieldName: Key): boolean {
+		const fieldSpec = this.#fields[fieldName]
+		const defaultValue = fieldSpec && 'default' in fieldSpec ? fieldSpec.default : undefined
+
+		const rawValue = this.#options[fieldName]
+		if (defaultValue !== undefined && rawValue === undefined) return Boolean(defaultValue)
+
+		return Boolean(rawValue)
+	}
+
+	async getParsedString<Key extends ConditionalKeys<TOptions, string | undefined>>(fieldName: Key): Promise<string> {
+		const rawValue = this.#options[fieldName]
+
+		return this.#context.parseVariablesInString(rawValue)
+	}
+	async getParsedNumber<Key extends ConditionalKeys<TOptions, string | undefined>>(fieldName: Key): Promise<number> {
+		const str = await this.getParsedString(fieldName)
+
+		return Number(str)
+	}
+}

--- a/src/module-api/action.ts
+++ b/src/module-api/action.ts
@@ -1,4 +1,4 @@
-import type { CompanionCommonCallbackContext } from './common.js'
+import type { CompanionCommonCallbackContext, StrictOptions, StrictOptionsObject } from './common.js'
 import type {
 	CompanionOptionValues,
 	CompanionInputFieldCheckbox,
@@ -30,6 +30,8 @@ export type CompanionActionContext = CompanionCommonCallbackContext
  * The definition of an action
  */
 export interface CompanionActionDefinition {
+	type?: 'loose'
+
 	/** Name to show in the actions list */
 	name: string
 	/** Additional description of the action */
@@ -92,4 +94,60 @@ export interface CompanionActionInfo {
 export interface CompanionActionEvent extends CompanionActionInfo {
 	/** Identifier of the surface which triggered this action */
 	readonly surfaceId: string | undefined
+}
+
+/**
+ * Basic information about an instance of an action
+ */
+export interface StrictActionInfo<TOptions> {
+	/** The unique id for this action */
+	readonly id: string
+	/** The unique id for the location of this action */
+	readonly controlId: string
+	/** The id of the action definition */
+	readonly actionId: string
+	/** The user selected options for the action */
+	readonly options: StrictOptions<TOptions>
+}
+/**
+ * Extended information for execution of an action
+ */
+export interface StrictActionEvent<TOptions> extends StrictActionInfo<TOptions> {
+	/** Identifier of the surface which triggered this action */
+	readonly surfaceId: string | undefined
+}
+
+export interface StrictActionDefinition<TOptions> {
+	type: 'strict'
+
+	/** Name to show in the actions list */
+	name: string
+	/** Additional description of the action */
+	description?: string
+	/** The input fields for the action */
+	options: StrictOptionsObject<TOptions, SomeCompanionActionInputField>
+
+	/** Called to execute the action */
+	callback: (action: StrictActionEvent<TOptions>, context: CompanionActionContext) => Promise<void> | void
+	/**
+	 * Called to report the existence of an action
+	 * Useful to ensure necessary data is loaded
+	 */
+	subscribe?: (action: StrictActionInfo<TOptions>, context: CompanionActionContext) => Promise<void> | void
+	/**
+	 * Called to report an action has been edited/removed
+	 * Useful to cleanup subscriptions setup in subscribe
+	 */
+	unsubscribe?: (action: StrictActionInfo<TOptions>, context: CompanionActionContext) => Promise<void> | void
+	/**
+	 * The user requested to 'learn' the values for this action.
+	 */
+	learn?: (
+		action: StrictActionEvent<TOptions>,
+		context: CompanionActionContext
+	) => TOptions | undefined | Promise<TOptions | undefined>
+}
+
+export type StrictActionDefinitions<TTypes> = {
+	[Key in keyof TTypes]: StrictActionDefinition<TTypes[Key]> | undefined
 }

--- a/src/module-api/common.ts
+++ b/src/module-api/common.ts
@@ -1,3 +1,6 @@
+import type { ConditionalKeys } from 'type-fest'
+import type { CompanionInputFieldBase } from './input.js'
+
 /**
  * Utility functions available in the context of an action/feedback
  */
@@ -9,4 +12,22 @@ export interface CompanionCommonCallbackContext {
 	 * @returns The string with variables replaced with their values
 	 */
 	parseVariablesInString(text: string): Promise<string>
+}
+
+export type StrictOptionsObject<TOptions, TFields extends CompanionInputFieldBase> = {
+	[K in keyof TOptions]: undefined extends TOptions[K] ? TFields | undefined : TFields
+}
+
+/**
+ *
+ */
+export interface StrictOptions<TOptions> {
+	getRawJson(): any
+	getRaw<Key extends keyof TOptions>(fieldName: Key): TOptions[Key] | undefined
+	getPlainString<Key extends ConditionalKeys<TOptions, string>>(fieldName: Key): TOptions[Key]
+	getPlainNumber<Key extends ConditionalKeys<TOptions, number>>(fieldName: Key): TOptions[Key]
+	getPlainBoolean<Key extends ConditionalKeys<TOptions, boolean>>(fieldName: Key): boolean
+
+	getParsedString<Key extends ConditionalKeys<TOptions, string | undefined>>(fieldName: Key): Promise<string>
+	getParsedNumber<Key extends ConditionalKeys<TOptions, string | undefined>>(fieldName: Key): Promise<number>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3932,6 +3932,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.15.0.tgz#21da206b89c15774cc718c4f2d693e13a1a14a43"
+  integrity sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==
+
 type@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"


### PR DESCRIPTION
This is based on some experimenting I did in the atem module https://github.com/bitfocus/companion-module-bmd-atem/pull/254

I am very interested in feedback/input from others on this.

Although there is no technical reason for it, I would like to propose making using these 'strict' types mandatory to support the use of location based variables in module actions and feedbacks. This is because it will help ensure that they are handled correctly, and mean that we have control over how the parsing is done, which will help minimise any impact to modules if we need to make future changes. Either way, modules will need to make changes to support location based variables.

The aim is to provide an action and feedback definitions which are strongly typed (to benefit modules using typescipt), and at the same time try to abstract away the parsing of variables. 
This has intentionally been done as a 'strict' version, without touching the existing types, so that modules can choose which version they use. This is to avoid it being a breaking change, and allow modules to migrate gradually if they want to, and to do so gradually.
Maybe in the future we will remove the looser flow, but unless it becomes incredibly messy to support both it likely won't be worth the effort.

As an example, some simple actions which use these types: https://github.com/bitfocus/companion-module-bmd-atem/blob/main/src/actions/aux.ts
And example feedbacks: https://github.com/bitfocus/companion-module-bmd-atem/blob/main/src/feedback/aux.ts
And presets: https://github.com/bitfocus/companion-module-bmd-atem/blob/main/src/presets/aux.ts



TODO:
- [ ] Some further thought is needed on upgrade scripts, as they will need to be aware of how the options are stored.
- [ ] `StrictOptionsImpl` should cache the values it has fetched/validated, so that modules don't need to think about whether they might be parsing the same string multiple times.
- [ ] It would be a good idea to take the opportunity to review the input field types, and consider if they need any tidying.
- [ ] The types of `StrictOptions` won't play nicely if we want to allow any support `useVariables: true` on number input fields. Perhaps all of the getters should be async so that we can allow this?
- [ ] Import and update the implementation of translating the existing flow to support these new types.
- [ ] Perhaps there should be another layer of interfaces, so that the StrictOptions knows what input field type is being used, and can reconfigure itself appropriately? Or perhaps StrictOptions should be a little less strict and shouldn't try to validate return types?