### PR TITLE
feat: Text preset type

### DIFF
--- a/src/host-api/api.ts
+++ b/src/host-api/api.ts
@@ -10,7 +10,7 @@ import type { OSCSomeArguments } from '../common/osc.js'
 import type { SomeCompanionConfigField } from '../module-api/config.js'
 import type { LogLevel, InstanceStatus } from '../module-api/enums.js'
 import type { InputValue, CompanionOptionValues, CompanionInputFieldBase } from '../module-api/input.js'
-import type { CompanionButtonPresetDefinition } from '../module-api/preset.js'
+import type { CompanionButtonPresetDefinition, CompanionTextPresetDefinition } from '../module-api/preset.js'
 import type { CompanionHTTPRequest, CompanionHTTPResponse } from '../module-api/http.js'
 import type { SomeCompanionActionInputField } from '../module-api/action.js'
 import type { CompanionVariableValue } from '../module-api/variable.js'
@@ -147,7 +147,7 @@ export interface SetVariableDefinitionsMessage {
 }
 
 export interface SetPresetDefinitionsMessage {
-	presets: Array<CompanionButtonPresetDefinition & { id: string }>
+	presets: Array<(CompanionButtonPresetDefinition | CompanionTextPresetDefinition) & { id: string }>
 }
 
 export interface SetVariableValuesMessage {

--- a/src/module-api/preset.ts
+++ b/src/module-api/preset.ts
@@ -44,6 +44,8 @@ export interface CompanionPresetAction {
 	options: CompanionOptionValues
 }
 
+export type CompanionPresetDefinition = CompanionButtonPresetDefinition | CompanionTextPresetDefinition
+
 /**
  * The definition of a press button preset
  */
@@ -63,6 +65,20 @@ export interface CompanionButtonPresetDefinition {
 	/** The feedbacks on the button */
 	feedbacks: CompanionPresetFeedback[]
 	steps: CompanionButtonStepActions[]
+}
+
+/**
+ * The definition of a text preset
+ */
+export interface CompanionTextPresetDefinition {
+		/** The type of this preset */
+		type: 'text'
+		/** The category of this preset, for grouping */
+		category: string
+		/** The name of this preset */
+		name: string
+		/** The text to display */
+		text: string
 }
 
 export interface CompanionPresetActionsWithOptions {
@@ -88,5 +104,5 @@ export interface CompanionButtonStepActions {
  * The definitions of a group of feedbacks
  */
 export interface CompanionPresetDefinitions {
-	[id: string]: CompanionButtonPresetDefinition | undefined
+	[id: string]: CompanionButtonPresetDefinition | CompanionTextPresetDefinition | undefined
 }


### PR DESCRIPTION
This, along with a PR to Companion itself (https://github.com/bitfocus/companion/pull/2846), will allow for the use of a `text` type preset as described in https://github.com/bitfocus/companion/issues/2843, and while not a full rework of the preset structure as suggested in that feature request the implementation of a text type does allow for modules to start utilizing it while consideration/changes to the preset structure take place at a later date.

The following is an example of some examples quickly placed in a module to show how they would be rendered when using something along the lines of
```js
{
  category: 'Mix 1',
  name: 'Test Header',
  type: 'text',
  text: 'Testing a text preset'
},
```
![companion-text-preset](https://github.com/bitfocus/companion-module-base/assets/12213790/51e065e5-213b-473d-b9e8-0be420468b13)

The `name` property takes the place of the header, while the `text` property will be in the paragraph below the header.

