### PR TITLE
fix: require at least one product to be defined in manifest.schema.json

### DIFF
--- a/assets/manifest.schema.json
+++ b/assets/manifest.schema.json
@@ -99,7 +99,8 @@
 			"uniqueItems": true,
 			"items": {
 				"type": "string"
-			}
+			},
+			"minItems": 1
 		},
 		"keywords": {
 			"type": "array",


### PR DESCRIPTION
Require at least one product to be listed in the manifest to prevent silent misconfiguration.

Closes https://github.com/bitfocus/companion-module-base/issues/81