### PR TITLE
fix: Resolving broadcast option within UDP Helper

### DIFF
--- a/src/helpers/udp.ts
+++ b/src/helpers/udp.ts
@@ -84,10 +84,6 @@ export class UDPHelper extends EventEmitter<UDPHelperEvents> {
 			)
 		}
 
-		if (this.#options.broadcast) {
-			this.#socket.setBroadcast(true)
-		}
-
 		if (this.#options.ttl !== undefined) {
 			this.#socket.setTTL(this.#options.ttl)
 		}
@@ -109,6 +105,11 @@ export class UDPHelper extends EventEmitter<UDPHelperEvents> {
 			// 		this.socket.addMembership(member.shift())
 			// 	}
 			// }
+
+			// Needed to be called after bind() had completed
+			if (this.#options.broadcast) {
+				this.#socket.setBroadcast(true)
+			}
 
 			if (this.#options.multicast_interface) {
 				this.#socket.setMulticastInterface(this.#options.multicast_interface)


### PR DESCRIPTION
Currently enabling broadcast within the constructor like this: `new UDPHelper(this.config.broadcastAddress, this.config.port, {broadcast: true})` throws a Bad File Descriptor. Which is caused by the call `setBroadcast()` being made before the socket has been initialized.

Moving `setBroadcast(true)` into the 'listening' event to better ensure that bind() has been completed successfully, resolves the EBADF error

As suggested on [Slack](https://bitfocusio.slack.com/archives/CFG7HAN5N/p1730804115675409) by Julian Waller