### PR TITLE
fix: add rinfo to UDPHelper message event

### DIFF
--- a/src/helpers/udp.ts
+++ b/src/helpers/udp.ts
@@ -27,7 +27,7 @@ export interface UDPHelperEvents {
 	// the socket is listening for packets
 	listening: []
 	// a packet of data has been received
-	data: [msg: Buffer, rinfo: Object]
+	data: [msg: Buffer, rinfo: dgram.RemoteInfo]
 
 	// the connection status changes
 	status_change: [status: UDPStatuses, message: string | undefined]

--- a/src/helpers/udp.ts
+++ b/src/helpers/udp.ts
@@ -27,7 +27,7 @@ export interface UDPHelperEvents {
 	// the socket is listening for packets
 	listening: []
 	// a packet of data has been received
-	data: [msg: Buffer]
+	data: [msg: Buffer, rinfo: Object]
 
 	// the connection status changes
 	status_change: [status: UDPStatuses, message: string | undefined]
@@ -119,11 +119,8 @@ export class UDPHelper extends EventEmitter<UDPHelperEvents> {
 			this.emit('listening')
 		})
 
-		// Extended event to include remote address info
-		this.#socket.on('message', (msg, rinfo) => {
-			this.emit('data', msg, rinfo)
-			this.emit('message', msg, rinfo)
-		});
+		// Passing on rinfo to emit instead of omitting it
+		this.#socket.on('message', (data, rinfo) => this.emit('data', data, rinfo))
 
 		this.#missingErrorHandlerTimer = setTimeout(() => {
 			if (!this.#destroyed && !this.listenerCount('error')) {

--- a/src/helpers/udp.ts
+++ b/src/helpers/udp.ts
@@ -84,10 +84,6 @@ export class UDPHelper extends EventEmitter<UDPHelperEvents> {
 			)
 		}
 
-		if (this.#options.broadcast) {
-			this.#socket.setBroadcast(true)
-		}
-
 		if (this.#options.ttl !== undefined) {
 			this.#socket.setTTL(this.#options.ttl)
 		}
@@ -109,6 +105,11 @@ export class UDPHelper extends EventEmitter<UDPHelperEvents> {
 			// 		this.socket.addMembership(member.shift())
 			// 	}
 			// }
+
+			// Needed to be called after bind() had completed
+			if (this.#options.broadcast) {
+				this.#socket.setBroadcast(true)
+			}
 
 			if (this.#options.multicast_interface) {
 				this.#socket.setMulticastInterface(this.#options.multicast_interface)

--- a/src/helpers/udp.ts
+++ b/src/helpers/udp.ts
@@ -119,7 +119,11 @@ export class UDPHelper extends EventEmitter<UDPHelperEvents> {
 			this.emit('listening')
 		})
 
-		this.#socket.on('message', (data) => this.emit('data', data))
+		// Extended event to include remote address info
+		this.#socket.on('message', (msg, rinfo) => {
+			this.emit('data', msg, rinfo)
+			this.emit('message', msg, rinfo)
+		});
 
 		this.#missingErrorHandlerTimer = setTimeout(() => {
 			if (!this.#destroyed && !this.listenerCount('error')) {


### PR DESCRIPTION
 - Added rinfo argument to message event as it was omitted.
 - Added emit to 'message' event for consistency.
 - Including original 'data' event for projects that expect it, as
well as rinfo.
 - Renamed data arg to msg, inline with nodejs api.