### PR TITLE
Add parseEscapeCharacters, substituteEscapeCharacters utility functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export * from './manifest.js'
 export * from './module-api/index.js'
 export * from './common/osc.js'
-export { literal, combineRgb, splitRgb, splitHsl, splitHsv, splitHex, RgbComponents, assertNever } from './util.js'
+export { literal, combineRgb, splitRgb, splitHsl, splitHsv, splitHex, RgbComponents, assertNever, parseEscapeCharacters, substituteEscapeCharacters } from './util.js'
 export * from './helpers/index.js'
 
 export { runEntrypoint } from './entrypoint.js'

--- a/src/util.ts
+++ b/src/util.ts
@@ -159,6 +159,10 @@ export function parseEscapeCharacters(msg: string): string {
 		.replaceAll('\\v', '\v')
 		.replaceAll('\\b', '\b')
 		.replaceAll('\\\\', '\\')
+		.replaceAll('\\x00', '\x00')
+		.replaceAll('\\x01', '\x01')
+		.replaceAll('\\x02', '\x02')
+		.replaceAll('\\x03', '\x03')
 	return message
 }
 
@@ -176,5 +180,9 @@ export function substituteEscapeCharacters(msg: string): string {
 		.replaceAll('\v', '\\v')
 		.replaceAll('\b', '\\b')
 		.replaceAll('\\', '\\\\')
+		.replaceAll('\x00', '\\x00')
+		.replaceAll('\x01', '\\x01')
+		.replaceAll('\x02', '\\x02')
+		.replaceAll('\x03', '\\x03')
 	return message
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -144,3 +144,37 @@ export function splitHex(color: number | string): string {
 export type Complete<T> = {
 	[P in keyof Required<T>]: Pick<T, P> extends Required<Pick<T, P>> ? T[P] : T[P] | undefined
 }
+
+/**
+ * Parse common escape characters in strings passed to callback from action or feedback options.
+ * This is useful to ensure \r, \n etc are represented as such rather than as \\r, \\n
+ */
+
+export function parseEscapeCharacters(msg: string): string {
+	const message = msg
+		.replaceAll('\\n', '\n')
+		.replaceAll('\\r', '\r')
+		.replaceAll('\\t', '\t')
+		.replaceAll('\\f', '\f')
+		.replaceAll('\\v', '\v')
+		.replaceAll('\\b', '\b')
+		.replaceAll('\\\\', '\\')
+	return message
+}
+
+/**
+ * The reverse of parseEscapeCharacters. This is useful to to ensure special charaters are displayed normally when returned to the UI.
+ * Ie during a learn callback, or as a variable
+ */
+
+export function substituteEscapeCharacters(msg: string): string {
+	const message = msg
+		.replaceAll('\n', '\\n')
+		.replaceAll('\r', '\\r')
+		.replaceAll('\t', '\\t')
+		.replaceAll('\f', '\\f')
+		.replaceAll('\v', '\\v')
+		.replaceAll('\b', '\\b')
+		.replaceAll('\\', '\\\\')
+	return message
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "./tsconfig.build.json",
 	"exclude": ["node_modules/**"],
 	"compilerOptions": {
-		"types": ["jest", "node"]
+		"types": ["jest", "node"],
+		"lib": ["ES2021.String"]
 	}
 }


### PR DESCRIPTION
Add `parseEscapeCharacters` utility function and its inverse. #https://github.com/bitfocus/companion/issues/3316