### PR TITLE
Fix: Incorrect type check for callback parameter in SharedUdpSocketImpl.send

### DIFF
--- a/src/module-api/shared-udp-socket.ts
+++ b/src/module-api/shared-udp-socket.ts
@@ -212,7 +212,7 @@ export class SharedUdpSocketImpl extends EventEmitter<SharedUdpSocketEvents> imp
 		if (typeof offsetOrPort !== 'number') throw new Error('Invalid arguments')
 		if (typeof lengthOrAddress === 'number') {
 			if (typeof portOrCallback !== 'number' || typeof address !== 'string') throw new Error('Invalid arguments')
-			if (callback !== undefined && typeof callback !== 'number') throw new Error('Invalid arguments')
+			if (callback !== undefined && typeof callback !== 'function') throw new Error('Invalid arguments')
 
 			const buffer = this.#processBuffer(bufferOrList, offsetOrPort, lengthOrAddress)
 			this.#sendInner(buffer, portOrCallback, address, callback)


### PR DESCRIPTION
This PR fixes an error in the SharedUdpSocketImpl.send method where the callback parameter was incorrectly being validated as a number instead of a function.

Bug discovered when passing a function to send threw a "Invalid Arguments" error.

Changes:
Updated type check from typeof callback !== 'number' to typeof callback !== 'function'

