### PR TITLE
Three updates to match other companion repos...

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 	"devDependencies": {
 		"@companion-module/tools": "^2.3.0",
 		"@tsconfig/node18": "^18.2.4",
-		"@tsconfig/node22": "^22.0.2",
 		"@types/ejson": "^2.2.2",
 		"@types/lodash-es": "^4.17.12",
 		"@types/node": "^18.19.123",

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tsconfig/node22/tsconfig.json",
+	"extends": "@tsconfig/node18/tsconfig.json",
 	"compilerOptions": {
 		"module": "CommonJS",
 		"moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,6 @@ __metadata:
   dependencies:
     "@companion-module/tools": "npm:^2.3.0"
     "@tsconfig/node18": "npm:^18.2.4"
-    "@tsconfig/node22": "npm:^22.0.2"
     "@types/ejson": "npm:^2.2.2"
     "@types/lodash-es": "npm:^4.17.12"
     "@types/node": "npm:^18.19.123"
@@ -722,13 +721,6 @@ __metadata:
   version: 18.2.4
   resolution: "@tsconfig/node18@npm:18.2.4"
   checksum: 10c0/cdfd17f212660374eb2765cd5907b2252e43cfa2623cd52307a49f004327ef49bbe7d53c78b0aca57f33e9a5cb0d7d2eb5ded9be1235e6212f65c9f0699322b6
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node22@npm:^22.0.2":
-  version: 22.0.2
-  resolution: "@tsconfig/node22@npm:22.0.2"
-  checksum: 10c0/c75e6b9ea86ec2a384adefac0e2f16a6c08202ae5cf6c8c745944396a6931ffb38e742809491c1882d1868c2af1c33744193701779674bfb1e05f6a130045a18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. comment out jest in *tsconfig.json* (as was done in companion-module-template-ts)
2. Add *.gitattributes* to force eol=LF
3. Update preset.ts so `CompanionButtonPresetDefinition` `previewStyle` matches the main companion repo *shared-lib/lib/Model/Presets.ts* `PresetDefinitionButton`

Note: should *tsconfig-base.json* "extends" be updated to reference node 22?  (@tsconfig/node22" would have to be added as well presumably?)

It would be nice if these could be added to a v1.12 release, if possible...