### PR TITLE
Set `process.title` on init and configUpdated

### DIFF
--- a/src/module-api/base.ts
+++ b/src/module-api/base.ts
@@ -191,7 +191,7 @@ export abstract class InstanceBase<TConfig, TSecrets = undefined> implements Ins
 			this.#lastSecrets = msg.secrets as TSecrets
 			this.#label = msg.label
 			process.title = msg.label
-			
+
 			// Create initial config object
 			if (msg.isFirstInit) {
 				const newConfig: any = {}


### PR DESCRIPTION
Set the NodeJS `process.title` to the connection label during init and configUpdated. Previously discussed in a [closed PR](https://github.com/bitfocus/companion-module-template-ts/pull/6) against the TS template, where it was suggested to do it in `module-base` instead.

This allows easier tracking of connection resource usage using tools such as `top` / `htop` on linux. This is not reported in Windows Task Manager, so does not help (nor hinder) on that platform. I am unsure if you can see this on MacOS.

I have been doing this directly inside modules I maintain for sometime, after realizing that at least on linux it made for much easier tracking than referencing PIDs.

Screenshot of `top` running on an Ubuntu VM running Companion where some of the connections have the process title set - it makes identification trivial. The ones that haven't (plus the main companion process), simply report `node`.

<img width="1740" height="1048" alt="image" src="https://github.com/user-attachments/assets/a0b4b820-1799-41e2-840e-4973da5bcf8b" />
