### PR TITLE
feat: document version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ In the future it will be possible to write modules in other languages, but it is
 
 Each version of Companion supports a limited range of versions of this library listed below. Any patch version (the third number) are not relevant for the compatibility check, so are not listed here
 
-| Companion | Module-base                |
-| --------- | -------------------------- |
-| v3.0      | v1.0 - v1.4                |
-| v3.1      | v1.0 - v1.5                |
-| v3.2      | v1.0 - v1.7                |
-| v3.3      | v1.0 - v1.8                |
-| v3.4      | v1.0 - v1.10               |
-| v3.5      | v1.0 - v1.11               |
-| v4.0      | v1.0 - v1.12               |
-| v4.1      | v1.0 - v1.13               |
-| v4.2      | v1.0 - v1.14               |
-| v4.3      | v1.0 - v1.15 (unconfirmed) |
+| Companion | Module-base                | Node.JS  | New Features in latest Module-base |
+| --------- | -------------------------- | -------- | --------------------------- |
+| v3.0      | v1.0 - v1.4                |   v18    | |
+| v3.1      | v1.0 - v1.5                |   v18    | |
+| v3.2      | v1.0 - v1.7                |   v18    | |
+| v3.3      | v1.0 - v1.8                |   v18    | |
+| v3.4      | v1.0 - v1.10               |   v18    | |
+| v3.5      | v1.0 - v1.11               | v18, v22 | nodejs v22 support |
+| v4.0      | v1.0 - v1.12               | v18, v22 | `isVisible` expressions |
+| v4.1      | v1.0 - v1.13               | v18, v22 | auto-process variables in text?, value feedback type, connection secrets, ...|
+| v4.2      | v1.0 - v1.14               | v18, v22 | |
+| v4.3      | v1.0 - v1.15 (unconfirmed) | v18, v22 | (dev) |
 
 ## Getting started with a new module
 


### PR DESCRIPTION
The "big" changes in each version of module-base are somewhat buried in the release notes and sometimes missing altogether. (For example which version introduced auto-processing of variables? I think it's 13 but couldn't find it mentioned in the release notes, whether through my own fault or its omission or ??? )

Regardless, it seem like it would be a good idea to highlight the major improvements in the version table, so here's my suggestion, partially filled in.