### PR TITLE
feat!: rework async behaviour of tcp/udp helpers

### DIFF
--- a/packages/companion-module-base/src/helpers/__tests__/tcp.spec.ts
+++ b/packages/companion-module-base/src/helpers/__tests__/tcp.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeAll, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest'
 import { TCPHelper } from '../tcp.js'
 import type { Socket as TMockSocket } from '../../__mocks__/net.js'
 import { Socket } from 'net'

--- a/packages/companion-module-base/src/helpers/tcp.ts
+++ b/packages/companion-module-base/src/helpers/tcp.ts
@@ -285,6 +285,8 @@ export class TCPHelper extends EventEmitter<TCPHelperEvents> {
 	 * All event listeners are removed and automatic reconnection is disabled.
 	 */
 	destroy(): void {
+		this.#connected = false
+		this.#connecting = false
 		this.#destroyed = true
 
 		if (this.#reconnectTimer !== undefined) {

--- a/packages/companion-module-base/src/helpers/telnet.ts
+++ b/packages/companion-module-base/src/helpers/telnet.ts
@@ -81,8 +81,11 @@ export class TelnetHelper extends EventEmitter<TelnetHelperEvents> {
 	connect(): boolean {
 		return this.#tcp.connect()
 	}
-	async send(message: string | Buffer): Promise<boolean> {
+	send(message: string | Buffer): boolean {
 		return this.#tcp.send(message)
+	}
+	async sendAsync(message: string | Buffer): Promise<boolean> {
+		return this.#tcp.sendAsync(message)
 	}
 
 	destroy(): void {

--- a/packages/companion-module-base/src/helpers/telnet.ts
+++ b/packages/companion-module-base/src/helpers/telnet.ts
@@ -183,6 +183,7 @@ export class TelnetHelper extends EventEmitter<TelnetHelperEvents> {
 		}
 
 		this.#stream.removeAllListeners()
+		this.removeAllListeners()
 		this.#stream.destroy()
 	}
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,10 +5,25 @@ import { defineConfig } from 'vite'
 export default defineConfig({
 	test: {
 		environment: 'node',
-		exclude: ['**/node_modules/**', '**/dist/**'],
 		coverage: {
 			provider: 'v8',
 			include: ['**/src/**/*.ts', '!**/node_modules/**'],
 		},
+		projects: [
+			{
+				test: {
+					name: 'base',
+					root: 'packages/companion-module-base',
+					exclude: ['**/node_modules/**', '**/dist/**'],
+				},
+			},
+			{
+				test: {
+					name: 'host',
+					root: 'packages/companion-module-host',
+					exclude: ['**/node_modules/**', '**/dist/**'],
+				},
+			},
+		],
 	},
 })


### PR DESCRIPTION
Closes #146

On the udp/tcp helpers, this makes the send method sync, with errors being emitted via the eventemitter, and adds a new sendAsync method which returns a promise and doesn't emit errors via the eventemitter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCP helper class with automatic reconnection, connection state visibility, and dual send interfaces (synchronous and asynchronous).
  * Added UDP helper class with lifecycle management and dual send interfaces.
  * Connection state now accessible through getters (isConnected, isConnecting, isDestroyed).

* **Refactor**
  * Telnet helper refactored to provide synchronous send and asynchronous sendAsync methods with improved resource cleanup.

* **Tests**
  * Comprehensive test coverage added for TCP and UDP helpers covering connection events, data handling, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->