### PR TITLE
Define insecure-algorithms permission property

### DIFF
--- a/assets/manifest.schema.json
+++ b/assets/manifest.schema.json
@@ -116,6 +116,10 @@
 						"filesystem": {
 							"type": "boolean",
 							"description": "Enable if the module requires read/write access to the filesystem"
+						},
+						"insecure-algorithms": {
+							"type": "boolean",
+							"description": "Enable if the module requires legacy openssl algorithms"
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
Define manifest permissions property to enable use of the `--openssl-legacy-provider` flag when starting connection process #187 
Requires [accompanying work](https://github.com/bitfocus/companion/pull/3967) in Companion to support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new insecure-algorithms permission option to module manifests, allowing users to explicitly control whether modules are permitted to use insecure algorithms at runtime. This provides enhanced security configuration and enables stricter compliance policies for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->