### PR TITLE
Add InsufficientPermissions to InstanceStatus enum

### DIFF
--- a/packages/companion-module-base/src/module-api/enums.ts
+++ b/packages/companion-module-base/src/module-api/enums.ts
@@ -11,7 +11,7 @@ export enum InstanceStatus {
 	UnknownError = 'unknown_error',
 	UnknownWarning = 'unknown_warning',
 	AuthenticationFailure = 'authentication_failure',
-	InsufficientPermissions = 'insufficient_permissions'
+	InsufficientPermissions = 'insufficient_permissions',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace


### PR DESCRIPTION
Anticipating some of the planned work around permissions management.
New status enum to communicate when connection has been run without the permissions required to complete a task.

Specifically my plan here is that the generic-snmp module checks to see if it has been run with --openssl-legacy-provider, and if it hasn't, and des priv protocol is selected return some useful status and logs to the user.

[PR for Companion](https://github.com/bitfocus/companion/pull/3991)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new status indicator for insufficient permissions, allowing the system to better communicate authorization issues to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->