### PR TITLE
chore: fix link to documentation

### DIFF
--- a/packages/companion-module-base/README.md
+++ b/packages/companion-module-base/README.md
@@ -32,4 +32,4 @@ To get started with creating a new module, you should start with one of the foll
 
 You can view detailed [generated documentation here](https://bitfocus.github.io/companion-module-base/).
 
-Or refer to [the wiki](https://github.com/bitfocus/companion-module-base/wiki) for a more handwritten version
+Or refer to [the developer documentation](https://companion.free/for-developers/module-development/) for more details and examples.


### PR DESCRIPTION
(from link to Wiki to Companion.free)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference links to direct users to developer documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->