### PR TITLE
feat: Allow action callbacks to return a result value

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -42,6 +42,7 @@
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {
-		"ajv": "^8.20.0"
+		"ajv": "^8.20.0",
+		"type-testing": "^0.2.0"
 	}
 }

--- a/packages/base/src/module-api/action.ts
+++ b/packages/base/src/module-api/action.ts
@@ -1,3 +1,11 @@
+import type {
+	Equal,
+	Expect,
+	ExpectFalse,
+	IsUnion,
+	// eslint-disable-next-line n/no-missing-import
+} from 'type-testing'
+import type { JsonValue } from '../common/json-value.js'
 import type { StringKeys } from '../util.js'
 import type { CompanionCommonCallbackContext, CompanionLearnCallbackContext } from './common.js'
 import type {
@@ -23,9 +31,66 @@ export type SomeCompanionActionInputField<TKey extends string = string> =
 	| CompanionInputFieldCheckbox<TKey>
 	| CompanionInputFieldCustomVariable<TKey>
 
-export interface CompanionActionSchema<TOptions extends CompanionOptionValues> {
+/** An action's options type must always be specified. */
+export interface CompanionActionSchemaOptions<TOptions extends CompanionOptionValues> {
+	/** The types of the action's options. */
 	options: TOptions
 }
+
+/**
+ * An action whose callback returns a result must specify the result type.
+ */
+export interface CompanionActionSchemaWithResult<
+	TOptions extends CompanionOptionValues,
+	TResult extends JsonValue,
+> extends CompanionActionSchemaOptions<TOptions> {
+	/**
+	 * The action callback returns a value of this type (possibly behind a
+	 * promise).
+	 */
+	result: TResult
+}
+
+/**
+ * An action whose callback doesn't return a result must not specify the result
+ * type.
+ */
+export interface CompanionActionSchemaWithoutResult<
+	TOptions extends CompanionOptionValues,
+> extends CompanionActionSchemaOptions<TOptions> {
+	/**
+	 * When no result type is specified, the action callback returns `void`
+	 * (possibly behind a promise).
+	 */
+	result?: never
+}
+
+/**
+ * Two kinds of action can be described:
+ *
+ *   * {@link CompanionActionSchemaWithResult}: an action with indicated options
+ *     that produces a result
+ *   * {@link CompanionActionSchemaWithoutResult}: an action with indicated
+ *     options that produces no result
+ */
+export type CompanionActionSchema<TOptions extends CompanionOptionValues, TResult extends JsonValue | void> =
+	// Don't distribute a union `TResult` across its constituent members.  The
+	// reason is subtle: action callbacks that return a result, return
+	// `TResult | Promise<TResult>`.  When `TResult` is a union, for example
+	// `TResult = M1 | ... | MN`, the callback therefore should return
+	// `M1 | ... | MN | Promise<M1 | ... | MN>`.  But if `TResult` is broken
+	// up, the distributed schema types will contain callbacks that return
+	// `M1 | Promise<M1>`, ..., `MN | Promise<MN>` -- which is not the same
+	// thing.
+	[TResult] extends [JsonValue]
+		? CompanionActionSchemaWithResult<TOptions, TResult>
+		: [TResult] extends [void]
+			? CompanionActionSchemaWithoutResult<TOptions>
+			: never
+
+type _CompanionActionSchemaDoesntDistributeUnionResult = ExpectFalse<
+	IsUnion<CompanionActionSchema<{ x: number }, number | string>>
+>
 
 /**
  * Utility functions available in the context of the current action
@@ -44,9 +109,12 @@ export interface CompanionActionContext extends CompanionCommonCallbackContext {
 export type CompanionActionLearnContext = CompanionLearnCallbackContext
 
 /**
- * The base definition of an action, which is augmented by the WithSubscribeHooks and WithoutSubscribeHooks definitions
+ * The base definition of an action, further augmented by:
+ *
+ *   * WithSubscribeHooks or WithoutSubscribeHooks definitions, and
+ *   * CallbackWithResult or CallbackWithoutResult definitions
  */
-export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionValues = CompanionOptionValues> {
+export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionValues> {
 	/** Name to show in the actions list */
 	name: string
 	/**
@@ -58,9 +126,6 @@ export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionV
 	description?: string
 	/** The input fields for the action */
 	options: SomeCompanionActionInputField<StringKeys<TOptions>>[]
-
-	/** Called to execute the action */
-	callback: (action: CompanionActionEvent<TOptions>, context: CompanionActionContext) => Promise<void> | void
 
 	/**
 	 * The user requested to 'learn' the values for this action.
@@ -77,6 +142,39 @@ export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionV
 	 * You can change this if this number does not work for you, but you should keep it to a sensible value
 	 */
 	learnTimeout?: number
+}
+
+/**
+ * The definition of an action that returns a result must opt into returning a
+ * result by specifying `hasResult: true`.
+ */
+export type CompanionActionDefinitionCallbackWithResult<
+	TOptions extends CompanionOptionValues,
+	TResult extends JsonValue,
+> = {
+	/**
+	 * A function called when the callback executes, potentially returning a
+	 * result value.
+	 */
+	callback: (action: CompanionActionEvent<TOptions>, context: CompanionActionContext) => Promise<TResult> | TResult
+
+	/* The callback returns a result. */
+	hasResult: true
+}
+
+/**
+ * The definition of an action that doesn't return a result omits `hasResult` or
+ * explicitly specifies `hasResult: false`.
+ */
+export type CompanionActionDefinitionCallbackWithoutResult<TOptions extends CompanionOptionValues> = {
+	/**
+	 * A function called when the callback executes, potentially returning a
+	 * result value.
+	 */
+	callback: (action: CompanionActionEvent<TOptions>, context: CompanionActionContext) => Promise<void> | void
+
+	/* The callback doesn't return a result. */
+	hasResult?: false
 }
 
 /**
@@ -118,22 +216,75 @@ export type CompanionActionDefinitionNoSubscribeHooks = {
 }
 
 /**
- * The complete definition of an action
+ * The definition of an action consists of the intersection of these fields:
+ *
+ *   * {@link CompanionActionDefinitionBase}: fields common to all actions
+ *   * {@link CompanionActionDefinitionCallbackWithResult} or
+ *     {@link CompanionActionDefinitionCallbackNoResult}: fields defining the
+ *     function to implement the action (and optionally return a result)
+ *   * {@link CompanionActionDefinitionSubscribeHooks} or
+ *     {@link CompanionActionDefinitionNoSubscribeHooks}: fields to optionally
+ *     define subscribe/unsubscribe functionality
  */
-export type CompanionActionDefinition<TOptions extends CompanionOptionValues = CompanionOptionValues> =
-	CompanionActionDefinitionBase<TOptions> &
-		(CompanionActionDefinitionSubscribeHooks<TOptions> | CompanionActionDefinitionNoSubscribeHooks)
+export type CompanionActionDefinition<
+	TSchema extends
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue> =
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>,
+> =
+	TSchema extends CompanionActionSchemaWithResult<infer Options, infer Result>
+		? CompanionActionDefinitionBase<Options> &
+				(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
+				CompanionActionDefinitionCallbackWithResult<Options, Result>
+		: TSchema extends CompanionActionSchemaWithoutResult<infer Options>
+			? CompanionActionDefinitionBase<Options> &
+					(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
+					CompanionActionDefinitionCallbackWithoutResult<Options>
+			: never
+
+// Verify that for `TResult = M1 | ... | MN`, the callback function returns
+// `M1 | ... | MN | Promise<M1 | ... | MN>`, not
+// `M1 | ... | MN | Promise<M1> | ... | Promise<MN>`.
+type _CallbackReturnTypePreservesUnionResult = Expect<
+	Equal<
+		ReturnType<CompanionActionDefinition<CompanionActionSchema<{ x: number }, number | string>>['callback']>,
+		number | string | Promise<number | string>
+	>
+>
 
 /**
- * The definitions of a group of actions
+ * The definition of a set of actions, as a record of
+ * {@link CompanionActionDefinition}s.
  */
 export type CompanionActionDefinitions<
-	Tschemas extends Record<string, CompanionActionSchema<CompanionOptionValues>> = Record<
+	Tschemas extends Record<
 		string,
-		CompanionActionSchema<CompanionOptionValues>
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
+	> = Record<
+		string,
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
 	>,
 > = {
-	[K in keyof Tschemas]: CompanionActionDefinition<Tschemas[K]['options']> | false | undefined
+	[K in keyof Tschemas]: Tschemas[K] extends infer Schema // just to abbreviate
+		? Schema extends CompanionActionSchemaWithResult<infer Options, infer Result>
+			?
+					| (CompanionActionDefinitionBase<Options> &
+							(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
+							CompanionActionDefinitionCallbackWithResult<Options, Result>)
+					| false
+					| undefined
+			: Schema extends CompanionActionSchemaWithoutResult<infer Options>
+				?
+						| (CompanionActionDefinitionBase<Options> &
+								(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
+								CompanionActionDefinitionCallbackWithoutResult<Options>)
+						| false
+						| undefined
+				: never
+		: never
 }
 
 /**

--- a/packages/base/src/module-api/action.ts
+++ b/packages/base/src/module-api/action.ts
@@ -114,7 +114,7 @@ export type CompanionActionLearnContext = CompanionLearnCallbackContext
  *   * WithSubscribeHooks or WithoutSubscribeHooks definitions, and
  *   * CallbackWithResult or CallbackWithoutResult definitions
  */
-export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionValues = CompanionOptionValues> {
+export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionValues> {
 	/** Name to show in the actions list */
 	name: string
 	/**
@@ -227,24 +227,28 @@ export type CompanionActionDefinitionNoSubscribeHooks = {
  *     define subscribe/unsubscribe functionality
  */
 export type CompanionActionDefinition<
-	TOptions extends CompanionOptionValues = CompanionOptionValues,
-	TResult extends JsonValue | void = void,
-> = [TResult] extends [void]
-	? CompanionActionDefinitionBase<TOptions> &
-			(CompanionActionDefinitionSubscribeHooks<TOptions> | CompanionActionDefinitionNoSubscribeHooks) &
-			CompanionActionDefinitionCallbackWithoutResult<TOptions>
-	: [TResult] extends [JsonValue]
-		? CompanionActionDefinitionBase<TOptions> &
-				(CompanionActionDefinitionSubscribeHooks<TOptions> | CompanionActionDefinitionNoSubscribeHooks) &
-				CompanionActionDefinitionCallbackWithResult<TOptions, TResult>
-		: never
+	TSchema extends
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue> =
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>,
+> =
+	TSchema extends CompanionActionSchemaWithResult<infer Options, infer Result>
+		? CompanionActionDefinitionBase<Options> &
+				(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
+				CompanionActionDefinitionCallbackWithResult<Options, Result>
+		: TSchema extends CompanionActionSchemaWithoutResult<infer Options>
+			? CompanionActionDefinitionBase<Options> &
+					(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
+					CompanionActionDefinitionCallbackWithoutResult<Options>
+			: never
 
 // Verify that for `TResult = M1 | ... | MN`, the callback function returns
 // `M1 | ... | MN | Promise<M1 | ... | MN>`, not
 // `M1 | ... | MN | Promise<M1> | ... | Promise<MN>`.
 type _CallbackReturnTypePreservesUnionResult = Expect<
 	Equal<
-		ReturnType<CompanionActionDefinition<{ x: number }, number | string>['callback']>,
+		ReturnType<CompanionActionDefinition<CompanionActionSchema<{ x: number }, number | string>>['callback']>,
 		number | string | Promise<number | string>
 	>
 >

--- a/packages/base/src/module-api/action.ts
+++ b/packages/base/src/module-api/action.ts
@@ -114,7 +114,7 @@ export type CompanionActionLearnContext = CompanionLearnCallbackContext
  *   * WithSubscribeHooks or WithoutSubscribeHooks definitions, and
  *   * CallbackWithResult or CallbackWithoutResult definitions
  */
-export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionValues> {
+export interface CompanionActionDefinitionBase<TOptions extends CompanionOptionValues = CompanionOptionValues> {
 	/** Name to show in the actions list */
 	name: string
 	/**
@@ -227,28 +227,24 @@ export type CompanionActionDefinitionNoSubscribeHooks = {
  *     define subscribe/unsubscribe functionality
  */
 export type CompanionActionDefinition<
-	TSchema extends
-		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
-		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue> =
-		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
-		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>,
-> =
-	TSchema extends CompanionActionSchemaWithResult<infer Options, infer Result>
-		? CompanionActionDefinitionBase<Options> &
-				(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
-				CompanionActionDefinitionCallbackWithResult<Options, Result>
-		: TSchema extends CompanionActionSchemaWithoutResult<infer Options>
-			? CompanionActionDefinitionBase<Options> &
-					(CompanionActionDefinitionSubscribeHooks<Options> | CompanionActionDefinitionNoSubscribeHooks) &
-					CompanionActionDefinitionCallbackWithoutResult<Options>
-			: never
+	TOptions extends CompanionOptionValues = CompanionOptionValues,
+	TResult extends JsonValue | void = void,
+> = [TResult] extends [void]
+	? CompanionActionDefinitionBase<TOptions> &
+			(CompanionActionDefinitionSubscribeHooks<TOptions> | CompanionActionDefinitionNoSubscribeHooks) &
+			CompanionActionDefinitionCallbackWithoutResult<TOptions>
+	: [TResult] extends [JsonValue]
+		? CompanionActionDefinitionBase<TOptions> &
+				(CompanionActionDefinitionSubscribeHooks<TOptions> | CompanionActionDefinitionNoSubscribeHooks) &
+				CompanionActionDefinitionCallbackWithResult<TOptions, TResult>
+		: never
 
 // Verify that for `TResult = M1 | ... | MN`, the callback function returns
 // `M1 | ... | MN | Promise<M1 | ... | MN>`, not
 // `M1 | ... | MN | Promise<M1> | ... | Promise<MN>`.
 type _CallbackReturnTypePreservesUnionResult = Expect<
 	Equal<
-		ReturnType<CompanionActionDefinition<CompanionActionSchema<{ x: number }, number | string>>['callback']>,
+		ReturnType<CompanionActionDefinition<{ x: number }, number | string>['callback']>,
 		number | string | Promise<number | string>
 	>
 >

--- a/packages/base/src/module-api/base.ts
+++ b/packages/base/src/module-api/base.ts
@@ -1,9 +1,14 @@
-import type { JsonObject } from '../common/json-value.js'
+import type { JsonObject, JsonValue } from '../common/json-value.js'
 import type { OSCSomeArguments } from '../common/osc.js'
 import { isInstanceContext, type InstanceContext } from '../host-api/context.js'
 import { createModuleLogger, type LogLevel, type ModuleLogger } from '../logging.js'
 import { assertNever, type StringKeys } from '../util.js'
-import type { CompanionActionDefinitions, CompanionActionSchema, CompanionRecordedAction } from './action.js'
+import type {
+	CompanionActionDefinitions,
+	CompanionActionSchemaWithoutResult,
+	CompanionActionSchemaWithResult,
+	CompanionRecordedAction,
+} from './action.js'
 import type { SomeCompanionConfigField } from './config.js'
 import type { InstanceStatus } from './enums.js'
 import type { CompanionFeedbackDefinitions, CompanionFeedbackSchema } from './feedback.js'
@@ -47,7 +52,11 @@ export interface InstanceBaseOptions {
 export interface InstanceTypes {
 	config: JsonObject
 	secrets: JsonObject | undefined
-	actions: Record<string, CompanionActionSchema<CompanionOptionValues>>
+	actions: Record<
+		string,
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
+	>
 	feedbacks: Record<string, CompanionFeedbackSchema<CompanionOptionValues>>
 	variables: CompanionVariableValues
 	compositeElements?: Record<string, CompanionCompositeElementSchema<CompanionOptionValues>>

--- a/packages/base/src/module-api/preset/definition.ts
+++ b/packages/base/src/module-api/preset/definition.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from '../../common/json-value.js'
-import type { CompanionActionSchema } from '../action.js'
+import type { CompanionActionSchemaWithoutResult, CompanionActionSchemaWithResult } from '../action.js'
 import type { InstanceTypes } from '../base.js'
 import type { CompanionFeedbackButtonStyleResult, CompanionFeedbackSchema } from '../feedback.js'
 import type { CompanionOptionValues, ExpressionOrValue } from '../input.js'
@@ -108,9 +108,14 @@ export interface CompanionButtonStepActions<TManifest extends InstanceTypes = In
  * The configuration of an action in a preset
  */
 export type CompanionPresetAction<
-	TActionManifest extends Record<string, CompanionActionSchema<CompanionOptionValues>> = Record<
+	TActionManifest extends Record<
 		string,
-		CompanionActionSchema<CompanionOptionValues>
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
+	> = Record<
+		string,
+		| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+		| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
 	>,
 > = {
 	[K in keyof TActionManifest]: {

--- a/packages/host/src/context.ts
+++ b/packages/host/src/context.ts
@@ -60,6 +60,7 @@ export interface HostActionDefinition {
 	sortName: string | undefined
 	description: string | undefined
 	options: SomeCompanionActionInputField[] // TODO module-lib - versioned types?
+	hasResult?: boolean
 	optionsToMonitorForSubscribe: string[] | undefined
 	hasLearn: boolean
 	learnTimeout: number | undefined

--- a/packages/host/src/instance.ts
+++ b/packages/host/src/instance.ts
@@ -9,6 +9,7 @@ import type {
 	InstanceBase,
 	InstanceConstructor,
 	InstanceTypes,
+	JsonValue,
 	SomeCompanionConfigField,
 } from '@companion-module/base'
 import type { InstanceContext, SharedUdpSocketMessage } from '@companion-module/base/host-api'
@@ -444,11 +445,20 @@ export interface InitResponseMessage {
 	updatedSecrets: unknown | undefined
 }
 
-export interface ExecuteActionResult {
-	success: boolean
-	/** If success=false, a reason for the failure */
-	errorMessage: string | undefined
+export interface ExecuteActionSuccess {
+	success: true
+	/**
+	 * The result returned by the callback, or `undefined` if the callback
+	 * doesn't return a result.
+	 */
+	result: JsonValue | undefined
 }
+export interface ExecuteActionFailure {
+	success: false
+	/** A reason for the failure */
+	errorMessage: string
+}
+export type ExecuteActionResult = ExecuteActionSuccess | ExecuteActionFailure
 
 export interface SharedUdpSocketError {
 	handleId: string

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -5,8 +5,11 @@ import {
 	type CompanionActionDefinitions,
 	type CompanionActionInfo,
 	type CompanionActionLearnContext,
+	type CompanionActionSchemaWithoutResult,
+	type CompanionActionSchemaWithResult,
 	type CompanionOptionValues,
 	type CompanionVariableValue,
+	type JsonValue,
 } from '@companion-module/base'
 import type { ActionInstance, HostActionDefinition } from '../context.js'
 import type { ExecuteActionResult } from '../instance.js'
@@ -31,7 +34,13 @@ export class ActionManager {
 		value: CompanionVariableValue | undefined,
 	) => void
 
-	readonly #actionDefinitions = new Map<string, CompanionActionDefinition>()
+	readonly #actionDefinitions = new Map<
+		string,
+		CompanionActionDefinition<
+			| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+			| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
+		>
+	>()
 	readonly #actionInstances = new Map<string, ActionInstance>()
 
 	constructor(
@@ -70,7 +79,7 @@ export class ActionManager {
 		}
 
 		try {
-			await actionDefinition.callback(
+			const result = await actionDefinition.callback(
 				{
 					id: action.id,
 					actionId: action.actionId,
@@ -84,7 +93,7 @@ export class ActionManager {
 
 			return {
 				success: true,
-				errorMessage: undefined,
+				result: actionDefinition.hasResult ? (result as JsonValue) : undefined,
 			}
 		} catch (e: any) {
 			return {
@@ -226,6 +235,7 @@ export class ActionManager {
 				sortName: action.sortName,
 				description: action.description,
 				options: action.options,
+				hasResult: !!action.hasResult,
 				optionsToMonitorForSubscribe: action.optionsToMonitorForSubscribe,
 				hasLearn: !!action.learn,
 				learnTimeout: action.learnTimeout,

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -5,8 +5,6 @@ import {
 	type CompanionActionDefinitions,
 	type CompanionActionInfo,
 	type CompanionActionLearnContext,
-	type CompanionActionSchemaWithoutResult,
-	type CompanionActionSchemaWithResult,
 	type CompanionOptionValues,
 	type CompanionVariableValue,
 	type JsonValue,
@@ -36,10 +34,7 @@ export class ActionManager {
 
 	readonly #actionDefinitions = new Map<
 		string,
-		CompanionActionDefinition<
-			| CompanionActionSchemaWithoutResult<CompanionOptionValues>
-			| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
-		>
+		CompanionActionDefinition<CompanionOptionValues, JsonValue> | CompanionActionDefinition<CompanionOptionValues, void>
 	>()
 	readonly #actionInstances = new Map<string, ActionInstance>()
 
@@ -55,7 +50,12 @@ export class ActionManager {
 		return this.#actionDefinitions.keys().toArray()
 	}
 
-	public getDefinition(id: string): CompanionActionDefinition | undefined {
+	public getDefinition(
+		id: string,
+	):
+		| CompanionActionDefinition<CompanionOptionValues, JsonValue>
+		| CompanionActionDefinition<CompanionOptionValues, void>
+		| undefined {
 		return this.#actionDefinitions.get(id)
 	}
 

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -5,6 +5,8 @@ import {
 	type CompanionActionDefinitions,
 	type CompanionActionInfo,
 	type CompanionActionLearnContext,
+	type CompanionActionSchemaWithoutResult,
+	type CompanionActionSchemaWithResult,
 	type CompanionOptionValues,
 	type CompanionVariableValue,
 	type JsonValue,
@@ -34,7 +36,10 @@ export class ActionManager {
 
 	readonly #actionDefinitions = new Map<
 		string,
-		CompanionActionDefinition<CompanionOptionValues, JsonValue> | CompanionActionDefinition<CompanionOptionValues, void>
+		CompanionActionDefinition<
+			| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+			| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
+		>
 	>()
 	readonly #actionInstances = new Map<string, ActionInstance>()
 
@@ -50,12 +55,7 @@ export class ActionManager {
 		return this.#actionDefinitions.keys().toArray()
 	}
 
-	public getDefinition(
-		id: string,
-	):
-		| CompanionActionDefinition<CompanionOptionValues, JsonValue>
-		| CompanionActionDefinition<CompanionOptionValues, void>
-		| undefined {
+	public getDefinition(id: string): CompanionActionDefinition | undefined {
 		return this.#actionDefinitions.get(id)
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,6 +137,7 @@ __metadata:
     ajv: "npm:^8.20.0"
     colord: "npm:^2.9.3"
     tslib: "npm:^2.8.1"
+    type-testing: "npm:^0.2.0"
   languageName: unknown
   linkType: soft
 
@@ -3047,6 +3048,13 @@ __metadata:
   dependencies:
     prelude-ls: "npm:^1.2.1"
   checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
+  languageName: node
+  linkType: hard
+
+"type-testing@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "type-testing@npm:0.2.0"
+  checksum: 10c0/7d4f9891bc31516a6b3ccf2278290da0c0c78a637cb0b4fe7b1a3c755a17d95530fc97ffd9af4e48cbee6073d9ed0ef3b0396916c44a6304d17da50103fed9a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is the `@companion-module/{base,host}` side of an implementation of a `context.setResult(value)` function, added for use in action callbacks, where the supplied value is then propagated into the next action in sequence as `$(this:result)`.

It might further be worth adding to `CompanionActionDefinition` an "exemplar" result value.  Button and expression previews obviously can't know what a preceding action *actually* returned.  It might be useful to have a sample value that can be fed into those preview mechanisms, in order to get somewhat better preview behavior than you get when `$(this:result)` is not the structured value you expect it to be.  But I did not implement this.

The only way I could figure out how to test this locally, in Companion, was to hard-code in `file:` module versions that mean this isn't immediately landable.  Those would need to change for this to be landed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions may declare typed results; callbacks can return those results.
  * Hosted action metadata now indicates whether an action yields a result, and action execution returns that result when present.

* **Bug Fixes**
  * Action execution responses are stricter: successful responses include an explicit result field (or undefined when none), failures always include an error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->