### PR TITLE
feat: make learn callbacks abortable

### DIFF
--- a/packages/base/src/module-api/action.ts
+++ b/packages/base/src/module-api/action.ts
@@ -1,4 +1,4 @@
-import type { CompanionCommonCallbackContext } from './common.js'
+import type { CompanionCommonCallbackContext, CompanionLearnCallbackContext } from './common.js'
 import type {
 	CompanionOptionValues,
 	CompanionInputFieldCheckbox,
@@ -40,6 +40,8 @@ export interface CompanionActionContext extends CompanionCommonCallbackContext {
 	 */
 	setCustomVariableValue(variableName: string, value: CompanionVariableValue): void
 }
+
+export type CompanionActionLearnContext = CompanionLearnCallbackContext
 
 /**
  * The definition of an action
@@ -88,7 +90,7 @@ export interface CompanionActionDefinition<TOptions extends CompanionOptionValue
 	 */
 	learn?: (
 		action: CompanionActionEvent<TOptions>,
-		context: CompanionActionContext,
+		context: CompanionActionLearnContext,
 	) => Partial<TOptions> | undefined | Promise<Partial<TOptions> | undefined>
 
 	/**

--- a/packages/base/src/module-api/common.ts
+++ b/packages/base/src/module-api/common.ts
@@ -8,7 +8,7 @@ export interface CompanionCommonCallbackContext {
 
 export interface CompanionLearnCallbackContext extends CompanionCommonCallbackContext {
 	/**
-	 * A signal that will abort if the user cancels the learn process. 
+	 * A signal that will abort if the user cancels the learn process.
 	 * Once the signal is aborted, the learn process should be stopped as soon as possible, with the return value or any thrown error being ignored.
 	 */
 	readonly signal: AbortSignal

--- a/packages/base/src/module-api/common.ts
+++ b/packages/base/src/module-api/common.ts
@@ -5,3 +5,11 @@ export interface CompanionCommonCallbackContext {
 	/** Whether this context is for an action or feedback */
 	readonly type: 'action' | 'feedback'
 }
+
+export interface CompanionLearnCallbackContext extends CompanionCommonCallbackContext {
+	/**
+	 * A signal that will abort if the user cancels the learn process. 
+	 * Once the signal is aborted, the learn process should be stopped as soon as possible, with the return value or any thrown error being ignored.
+	 */
+	readonly signal: AbortSignal
+}

--- a/packages/base/src/module-api/feedback.ts
+++ b/packages/base/src/module-api/feedback.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from '../common/json-value.js'
-import type { CompanionCommonCallbackContext } from './common.js'
+import type { CompanionCommonCallbackContext, CompanionLearnCallbackContext } from './common.js'
 import type {
 	CompanionOptionValues,
 	CompanionInputFieldStaticText,
@@ -139,7 +139,7 @@ export interface CompanionFeedbackDefinitionBase<TOptions extends CompanionOptio
 	 */
 	learn?: (
 		feedback: CompanionFeedbackInfo<TOptions>,
-		context: CompanionFeedbackContext,
+		context: CompanionFeedbackLearnContext,
 	) => Partial<TOptions> | undefined | Promise<Partial<TOptions> | undefined>
 
 	/**
@@ -207,6 +207,7 @@ export interface CompanionAdvancedFeedbackDefinition<
  * Utility functions available in the context of the current feedback
  */
 export type CompanionFeedbackContext = CompanionCommonCallbackContext
+export type CompanionFeedbackLearnContext = CompanionLearnCallbackContext
 
 /**
  * The definition of some feedback

--- a/packages/host/src/instance.ts
+++ b/packages/host/src/instance.ts
@@ -353,7 +353,7 @@ export class InstanceWrapper<TManifest extends InstanceTypes> {
 	 * @deprecated use learnActionWithSignal instead, which allows passing an AbortSignal to the learn function, so that it can be cancelled if needed
 	 */
 	async learnAction(action: ActionInstance): Promise<{ options: CompanionOptionValues | undefined }> {
-		// Creat a constant signal that will never abort
+		// Create a constant signal that will never abort
 		const signal = new AbortController().signal
 
 		return this.#actionManager.handleLearnAction(action, signal)
@@ -368,7 +368,7 @@ export class InstanceWrapper<TManifest extends InstanceTypes> {
 	 * @deprecated use learnFeedbackWithSignal instead, which allows passing an AbortSignal to the learn function, so that it can be cancelled if needed
 	 */
 	async learnFeedback(feedback: FeedbackInstance): Promise<{ options: CompanionOptionValues | undefined }> {
-		// Creat a constant signal that will never abort
+		// Create a constant signal that will never abort
 		const signal = new AbortController().signal
 
 		return this.#feedbackManager.handleLearnFeedback(feedback, signal)

--- a/packages/host/src/instance.ts
+++ b/packages/host/src/instance.ts
@@ -349,11 +349,35 @@ export class InstanceWrapper<TManifest extends InstanceTypes> {
 
 		return res
 	}
+	/**
+	 * @deprecated use learnActionWithSignal instead, which allows passing an AbortSignal to the learn function, so that it can be cancelled if needed
+	 */
 	async learnAction(action: ActionInstance): Promise<{ options: CompanionOptionValues | undefined }> {
-		return this.#actionManager.handleLearnAction(action)
+		// Creat a constant signal that will never abort
+		const signal = new AbortController().signal
+
+		return this.#actionManager.handleLearnAction(action, signal)
 	}
+	async learnActionWithSignal(
+		action: ActionInstance,
+		signal: AbortSignal,
+	): Promise<{ options: CompanionOptionValues | undefined }> {
+		return this.#actionManager.handleLearnAction(action, signal)
+	}
+	/**
+	 * @deprecated use learnFeedbackWithSignal instead, which allows passing an AbortSignal to the learn function, so that it can be cancelled if needed
+	 */
 	async learnFeedback(feedback: FeedbackInstance): Promise<{ options: CompanionOptionValues | undefined }> {
-		return this.#feedbackManager.handleLearnFeedback(feedback)
+		// Creat a constant signal that will never abort
+		const signal = new AbortController().signal
+
+		return this.#feedbackManager.handleLearnFeedback(feedback, signal)
+	}
+	async learnFeedbackWithSignal(
+		feedback: FeedbackInstance,
+		signal: AbortSignal,
+	): Promise<{ options: CompanionOptionValues | undefined }> {
+		return this.#feedbackManager.handleLearnFeedback(feedback, signal)
 	}
 	async startStopRecordActions(recording: boolean): Promise<void> {
 		if (!recording) {

--- a/packages/host/src/internal/__tests__/feedback.spec.ts
+++ b/packages/host/src/internal/__tests__/feedback.spec.ts
@@ -7,6 +7,7 @@ import type {
 	CompanionBooleanFeedbackDefinition,
 	CompanionFeedbackDefinition,
 	CompanionFeedbackDefinitionBase,
+	CompanionOptionValues,
 } from '@companion-module/base'
 
 const mockDefinitionId = 'definition0'
@@ -520,7 +521,7 @@ describe('FeedbackManager', () => {
 		})
 	})
 
-	it('learn values: no implementation', async () => {
+	it('learn values: no implementation', async (ctx) => {
 		const mockSetFeedbackDefinitions = vi.fn((_feedbacks: HostFeedbackDefinition[]) => null)
 		const manager = new FeedbackManager(mockSetFeedbackDefinitions, unimplementedFunction)
 		expect(manager.getDefinitionIds()).toHaveLength(0)
@@ -541,10 +542,10 @@ describe('FeedbackManager', () => {
 		expect(mockDefinition.callback).toHaveBeenCalledTimes(0)
 
 		// make the call
-		await expect(manager.handleLearnFeedback(feedback)).resolves.toEqual({ options: undefined })
+		await expect(manager.handleLearnFeedback(feedback, ctx.signal)).resolves.toEqual({ options: undefined })
 	})
 
-	it('learn values: with implementation', async () => {
+	it('learn values: with implementation', async (ctx) => {
 		const mockSetFeedbackDefinitions = vi.fn((_feedbacks: HostFeedbackDefinition[]) => null)
 		const manager = new FeedbackManager(mockSetFeedbackDefinitions, unimplementedFunction)
 		expect(manager.getDefinitionIds()).toHaveLength(0)
@@ -566,7 +567,7 @@ describe('FeedbackManager', () => {
 		expect(mockDefinition.callback).toHaveBeenCalledTimes(0)
 
 		// make the call
-		await expect(manager.handleLearnFeedback(feedback)).resolves.toEqual({ options: { abc: 123 } })
+		await expect(manager.handleLearnFeedback(feedback, ctx.signal)).resolves.toEqual({ options: { abc: 123 } })
 		expect(mockDefinition.learn).toBeCalledTimes(1)
 		expect(mockDefinition.learn).lastCalledWith(
 			{
@@ -579,6 +580,98 @@ describe('FeedbackManager', () => {
 			},
 			expect.anything(),
 		)
+	})
+
+	it('learn values: signal is forwarded to learn callback context', async () => {
+		const mockSetFeedbackDefinitions = vi.fn((_feedbacks: HostFeedbackDefinition[]) => null)
+		const manager = new FeedbackManager(mockSetFeedbackDefinitions, unimplementedFunction)
+
+		const mockDefinitionId = 'definition0'
+		let capturedSignal: AbortSignal | undefined
+		const mockDefinition: CompanionFeedbackDefinition = {
+			type: 'boolean',
+			name: 'Definition0',
+			defaultStyle: {},
+			options: [],
+			callback: vi.fn<CompanionBooleanFeedbackDefinition['callback']>(() => false),
+			learn: vi.fn<Required<CompanionFeedbackDefinitionBase>['learn']>((_fb, ctx) => {
+				capturedSignal = ctx.signal
+				return { abc: 123 }
+			}),
+		}
+
+		manager.setFeedbackDefinitions({ [mockDefinitionId]: mockDefinition })
+
+		const controller = new AbortController()
+		await manager.handleLearnFeedback(feedback, controller.signal)
+
+		expect(capturedSignal).toBe(controller.signal)
+		expect(capturedSignal!.aborted).toBe(false)
+	})
+
+	it('learn values: pre-aborted signal is forwarded to learn callback', async () => {
+		const mockSetFeedbackDefinitions = vi.fn((_feedbacks: HostFeedbackDefinition[]) => null)
+		const manager = new FeedbackManager(mockSetFeedbackDefinitions, unimplementedFunction)
+
+		const mockDefinitionId = 'definition0'
+		let capturedSignal: AbortSignal | undefined
+		const mockDefinition: CompanionFeedbackDefinition = {
+			type: 'boolean',
+			name: 'Definition0',
+			defaultStyle: {},
+			options: [],
+			callback: vi.fn<CompanionBooleanFeedbackDefinition['callback']>(() => false),
+			learn: vi.fn<Required<CompanionFeedbackDefinitionBase>['learn']>((_fb, ctx) => {
+				capturedSignal = ctx.signal
+				return { abc: 123 }
+			}),
+		}
+
+		manager.setFeedbackDefinitions({ [mockDefinitionId]: mockDefinition })
+
+		const controller = new AbortController()
+		controller.abort()
+
+		// learn is still called even when the signal is already aborted
+		await expect(manager.handleLearnFeedback(feedback, controller.signal)).resolves.toEqual({ options: { abc: 123 } })
+		expect(mockDefinition.learn).toBeCalledTimes(1)
+		expect(capturedSignal).toBe(controller.signal)
+		expect(capturedSignal!.aborted).toBe(true)
+	})
+
+	it('learn values: signal aborted mid-execution is observable by learn callback', async () => {
+		const mockSetFeedbackDefinitions = vi.fn((_feedbacks: HostFeedbackDefinition[]) => null)
+		const manager = new FeedbackManager(mockSetFeedbackDefinitions, unimplementedFunction)
+
+		const mockDefinitionId = 'definition0'
+		const controller = new AbortController()
+
+		let resolveLearn: ((value: CompanionOptionValues) => void) | undefined
+		const mockDefinition: CompanionFeedbackDefinition = {
+			type: 'boolean',
+			name: 'Definition0',
+			defaultStyle: {},
+			options: [],
+			callback: vi.fn<CompanionBooleanFeedbackDefinition['callback']>(() => false),
+			learn: vi.fn<Required<CompanionFeedbackDefinitionBase>['learn']>(async (_fb, ctx) => {
+				return new Promise<CompanionOptionValues>((resolve) => {
+					resolveLearn = resolve
+					// abort mid-execution and resolve with the aborted state observable
+					ctx.signal.addEventListener('abort', () => resolve({ wasAborted: true }))
+				})
+			}),
+		}
+
+		manager.setFeedbackDefinitions({ [mockDefinitionId]: mockDefinition })
+
+		const learnPromise = manager.handleLearnFeedback(feedback, controller.signal)
+
+		// learn is in-flight, abort the signal
+		expect(resolveLearn).toBeDefined()
+		controller.abort()
+
+		await expect(learnPromise).resolves.toEqual({ options: { wasAborted: true } })
+		expect(mockDefinition.learn).toBeCalledTimes(1)
 	})
 
 	describe('unsubscribe', () => {

--- a/packages/host/src/internal/__tests__/feedback.spec.ts
+++ b/packages/host/src/internal/__tests__/feedback.spec.ts
@@ -609,20 +609,18 @@ describe('FeedbackManager', () => {
 		expect(capturedSignal!.aborted).toBe(false)
 	})
 
-	it('learn values: pre-aborted signal is forwarded to learn callback', async () => {
+	it('learn values: pre-aborted signal skips learn callback', async () => {
 		const mockSetFeedbackDefinitions = vi.fn((_feedbacks: HostFeedbackDefinition[]) => null)
 		const manager = new FeedbackManager(mockSetFeedbackDefinitions, unimplementedFunction)
 
 		const mockDefinitionId = 'definition0'
-		let capturedSignal: AbortSignal | undefined
 		const mockDefinition: CompanionFeedbackDefinition = {
 			type: 'boolean',
 			name: 'Definition0',
 			defaultStyle: {},
 			options: [],
 			callback: vi.fn<CompanionBooleanFeedbackDefinition['callback']>(() => false),
-			learn: vi.fn<Required<CompanionFeedbackDefinitionBase>['learn']>((_fb, ctx) => {
-				capturedSignal = ctx.signal
+			learn: vi.fn<Required<CompanionFeedbackDefinitionBase>['learn']>(() => {
 				return { abc: 123 }
 			}),
 		}
@@ -632,11 +630,9 @@ describe('FeedbackManager', () => {
 		const controller = new AbortController()
 		controller.abort()
 
-		// learn is still called even when the signal is already aborted, but result is discarded
+		// learn is NOT called when the signal is already aborted; result is undefined
 		await expect(manager.handleLearnFeedback(feedback, controller.signal)).resolves.toEqual({ options: undefined })
-		expect(mockDefinition.learn).toBeCalledTimes(1)
-		expect(capturedSignal).toBe(controller.signal)
-		expect(capturedSignal!.aborted).toBe(true)
+		expect(mockDefinition.learn).toBeCalledTimes(0)
 	})
 
 	it('learn values: signal aborted mid-execution is observable by learn callback', async () => {

--- a/packages/host/src/internal/__tests__/feedback.spec.ts
+++ b/packages/host/src/internal/__tests__/feedback.spec.ts
@@ -632,8 +632,8 @@ describe('FeedbackManager', () => {
 		const controller = new AbortController()
 		controller.abort()
 
-		// learn is still called even when the signal is already aborted
-		await expect(manager.handleLearnFeedback(feedback, controller.signal)).resolves.toEqual({ options: { abc: 123 } })
+		// learn is still called even when the signal is already aborted, but result is discarded
+		await expect(manager.handleLearnFeedback(feedback, controller.signal)).resolves.toEqual({ options: undefined })
 		expect(mockDefinition.learn).toBeCalledTimes(1)
 		expect(capturedSignal).toBe(controller.signal)
 		expect(capturedSignal!.aborted).toBe(true)
@@ -670,7 +670,8 @@ describe('FeedbackManager', () => {
 		expect(resolveLearn).toBeDefined()
 		controller.abort()
 
-		await expect(learnPromise).resolves.toEqual({ options: { wasAborted: true } })
+		// the abort causes learn to resolve, but the result is discarded because the signal is aborted
+		await expect(learnPromise).resolves.toEqual({ options: undefined })
 		expect(mockDefinition.learn).toBeCalledTimes(1)
 	})
 

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -166,11 +166,18 @@ export class ActionManager {
 					context,
 				)
 
+				if (signal.aborted) {
+					// The learn was aborted, return undefined options as a signal of this
+					return {
+						options: undefined,
+					}
+				}
+
 				return {
 					options: newOptions,
 				}
 			} catch (e) {
-				if (e === signal.reason) {
+				if (signal.aborted) {
 					// The learn was aborted, return undefined options as a signal of this
 					return {
 						options: undefined,

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -153,20 +153,31 @@ export class ActionManager {
 				signal,
 			}
 
-			const newOptions = await definition.learn(
-				{
-					id: action.id,
-					actionId: action.actionId,
-					controlId: action.controlId,
-					options: action.options,
+			try {
+				const newOptions = await definition.learn(
+					{
+						id: action.id,
+						actionId: action.actionId,
+						controlId: action.controlId,
+						options: action.options,
 
-					surfaceId: undefined,
-				},
-				context,
-			)
+						surfaceId: undefined,
+					},
+					context,
+				)
 
-			return {
-				options: newOptions,
+				return {
+					options: newOptions,
+				}
+			} catch (e) {
+				if (e === signal.reason) {
+					// The learn was aborted, return undefined options as a signal of this
+					return {
+						options: undefined,
+					}
+				} else {
+					throw e
+				}
 			}
 		} else {
 			// Not supported

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -3,7 +3,7 @@ import {
 	type CompanionActionDefinition,
 	type CompanionActionDefinitions,
 	type CompanionActionInfo,
-	CompanionActionLearnContext,
+	type CompanionActionLearnContext,
 	type CompanionOptionValues,
 	type CompanionVariableValue,
 	createModuleLogger,

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -153,6 +153,13 @@ export class ActionManager {
 				signal,
 			}
 
+			if (signal.aborted) {
+				// The learn was aborted, return undefined options as a signal of this
+				return {
+					options: undefined,
+				}
+			}
+
 			try {
 				const newOptions = await definition.learn(
 					{

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -3,6 +3,7 @@ import {
 	type CompanionActionDefinition,
 	type CompanionActionDefinitions,
 	type CompanionActionInfo,
+	CompanionActionLearnContext,
 	type CompanionOptionValues,
 	type CompanionVariableValue,
 	createModuleLogger,
@@ -141,14 +142,15 @@ export class ActionManager {
 		}
 	}
 
-	public async handleLearnAction(action: ActionInstance): Promise<{ options: CompanionOptionValues | undefined }> {
+	public async handleLearnAction(
+		action: ActionInstance,
+		signal: AbortSignal,
+	): Promise<{ options: CompanionOptionValues | undefined }> {
 		const definition = this.#actionDefinitions.get(action.actionId)
 		if (definition && definition.learn) {
-			const context: CompanionActionContext = {
+			const context: CompanionActionLearnContext = {
 				type: 'action',
-				setCustomVariableValue: () => {
-					throw new Error(`setCustomVariableValue is not available during learn`)
-				},
+				signal,
 			}
 
 			const newOptions = await definition.learn(

--- a/packages/host/src/internal/feedback.ts
+++ b/packages/host/src/internal/feedback.ts
@@ -4,6 +4,7 @@ import {
 	type CompanionFeedbackDefinition,
 	type CompanionFeedbackDefinitions,
 	type CompanionFeedbackInfo,
+	CompanionFeedbackLearnContext,
 	type CompanionOptionValues,
 	type JsonValue,
 	assertNever,
@@ -113,11 +114,13 @@ export class FeedbackManager {
 
 	public async handleLearnFeedback(
 		feedback: FeedbackInstance,
+		signal: AbortSignal,
 	): Promise<{ options: CompanionOptionValues | undefined }> {
 		const definition = this.#feedbackDefinitions.get(feedback.feedbackId)
 		if (definition && definition.learn) {
-			const context: CompanionFeedbackContext = {
+			const context: CompanionFeedbackLearnContext = {
 				type: 'feedback',
+				signal,
 			}
 
 			const newOptions = await definition.learn(

--- a/packages/host/src/internal/feedback.ts
+++ b/packages/host/src/internal/feedback.ts
@@ -123,6 +123,13 @@ export class FeedbackManager {
 				signal,
 			}
 
+			if (signal.aborted) {
+				// The learn was aborted, return undefined options as a signal of this
+				return {
+					options: undefined,
+				}
+			}
+
 			try {
 				const newOptions = await definition.learn(
 					{

--- a/packages/host/src/internal/feedback.ts
+++ b/packages/host/src/internal/feedback.ts
@@ -4,7 +4,7 @@ import {
 	type CompanionFeedbackDefinition,
 	type CompanionFeedbackDefinitions,
 	type CompanionFeedbackInfo,
-	CompanionFeedbackLearnContext,
+	type CompanionFeedbackLearnContext,
 	type CompanionOptionValues,
 	type JsonValue,
 	assertNever,

--- a/packages/host/src/internal/feedback.ts
+++ b/packages/host/src/internal/feedback.ts
@@ -123,20 +123,31 @@ export class FeedbackManager {
 				signal,
 			}
 
-			const newOptions = await definition.learn(
-				{
-					id: feedback.id,
-					feedbackId: feedback.feedbackId,
-					controlId: feedback.controlId,
-					options: feedback.options,
-					previousOptions: null,
-					type: definition.type,
-				},
-				context,
-			)
+			try {
+				const newOptions = await definition.learn(
+					{
+						id: feedback.id,
+						feedbackId: feedback.feedbackId,
+						controlId: feedback.controlId,
+						options: feedback.options,
+						previousOptions: null,
+						type: definition.type,
+					},
+					context,
+				)
 
-			return {
-				options: newOptions,
+				return {
+					options: newOptions,
+				}
+			} catch (e) {
+				if (e === signal.reason) {
+					// The learn was aborted, return undefined options as a signal of this
+					return {
+						options: undefined,
+					}
+				} else {
+					throw e
+				}
 			}
 		} else {
 			// Not supported

--- a/packages/host/src/internal/feedback.ts
+++ b/packages/host/src/internal/feedback.ts
@@ -136,11 +136,18 @@ export class FeedbackManager {
 					context,
 				)
 
+				if (signal.aborted) {
+					// The learn was aborted, return undefined options as a signal of this
+					return {
+						options: undefined,
+					}
+				}
+
 				return {
 					options: newOptions,
 				}
 			} catch (e) {
-				if (e === signal.reason) {
+				if (signal.aborted) {
 					// The learn was aborted, return undefined options as a signal of this
 					return {
 						options: undefined,


### PR DESCRIPTION
The learn callbacks are expected to often be long-running, with a custom timeout duation.

This allows companion to propagate an abortsignal to allow for indicating to the module that the user has canceled the in-progress learn operation, and to let the module do appropriate cleanup when that happens, instead of running to completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Learn operations now accept an AbortSignal so callers can cancel learns; aborted learns return no options and discard in-flight results.
  * Learn callback contexts now expose the abort signal to observe cancellation.
* **Deprecations**
  * Legacy learn methods without a signal are deprecated in favor of signal-taking variants.
* **Tests**
  * Learn tests updated to verify signal forwarding, pre-aborted behavior, in-flight abort visibility, and result handling after abort.
* **Documentation**
  * Documentation entry points adjusted to improve generated API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->