### PR TITLE
feat: allow internal actions and feedbacks in presets

### DIFF
--- a/packages/base/src/module-api/preset/__tests__/internal-catalog.spec.ts
+++ b/packages/base/src/module-api/preset/__tests__/internal-catalog.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { InstanceTypes } from '../../base.js'
+import type { CompanionSimplePresetDefinition } from '../definition.js'
+import { INTERNAL_PRESET_MIN_API_VERSION } from '../internal-catalog.js'
+
+// A concrete manifest so that the merged internal ids are surfaced precisely (rather than the loose
+// string-index default). This exercises the type-level merge of internal:* schemas into presets.
+interface TestManifest extends InstanceTypes {
+	config: Record<string, never>
+	secrets: undefined
+	actions: { myAction: { options: { foo: string } } }
+	feedbacks: { myFeedback: { type: 'boolean'; options: { bar: number } } }
+	variables: Record<string, never>
+}
+
+describe('internal preset catalog', () => {
+	it('exposes a min api version for every catalog id', () => {
+		// Spot-check a couple of ids and that all entries are valid semver-ish strings
+		expect(INTERNAL_PRESET_MIN_API_VERSION['internal:wait']).toBe('2.1.0-0')
+		expect(INTERNAL_PRESET_MIN_API_VERSION['internal:checkExpression']).toBe('2.1.0-0')
+		for (const version of Object.values(INTERNAL_PRESET_MIN_API_VERSION)) {
+			expect(typeof version).toBe('string')
+		}
+	})
+
+	it('allows a preset to mix the module’s own and internal actions/feedbacks (type-level)', () => {
+		const preset: CompanionSimplePresetDefinition<TestManifest> = {
+			type: 'simple',
+			name: 'Mixed',
+			style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+			steps: [
+				{
+					down: [
+						{ actionId: 'myAction', options: { foo: 'a' } },
+						{ actionId: 'internal:wait', options: { time: 100 } },
+						{ actionId: 'internal:customLog', options: { message: 'hi' } },
+					],
+					up: [],
+				},
+			],
+			feedbacks: [
+				{ feedbackId: 'myFeedback', options: { bar: 1 }, style: { color: 1 } },
+				{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' }, style: { bgcolor: 0xff0000 } },
+			],
+		}
+		expect(preset.steps[0].down).toHaveLength(3)
+	})
+
+	it('rejects unknown internal ids and missing style on boolean internal feedbacks (type-level)', () => {
+		const preset: CompanionSimplePresetDefinition<TestManifest> = {
+			type: 'simple',
+			name: 'Bad',
+			style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+			steps: [
+				{
+					down: [
+						// @ts-expect-error 'internal:nope' is not a known internal action id
+						{ actionId: 'internal:nope', options: {} },
+					],
+					up: [],
+				},
+			],
+			feedbacks: [
+				// @ts-expect-error a boolean internal feedback must provide a style
+				{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } },
+			],
+		}
+		expect(preset.name).toBe('Bad')
+	})
+})

--- a/packages/base/src/module-api/preset/__tests__/internal-catalog.spec.ts
+++ b/packages/base/src/module-api/preset/__tests__/internal-catalog.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { InstanceTypes } from '../../base.js'
+import type { CompanionLayeredButtonPresetDefinition } from '../definition-graphics.js'
 import type { CompanionSimplePresetDefinition } from '../definition.js'
 import { INTERNAL_PRESET_MIN_API_VERSION } from '../internal-catalog.js'
 
@@ -9,7 +10,10 @@ interface TestManifest extends InstanceTypes {
 	config: Record<string, never>
 	secrets: undefined
 	actions: { myAction: { options: { foo: string } } }
-	feedbacks: { myFeedback: { type: 'boolean'; options: { bar: number } } }
+	feedbacks: {
+		myFeedback: { type: 'boolean'; options: { bar: number } }
+		myAdvanced: { type: 'advanced'; options: Record<string, never> }
+	}
 	variables: Record<string, never>
 }
 
@@ -66,5 +70,140 @@ describe('internal preset catalog', () => {
 			],
 		}
 		expect(preset.name).toBe('Bad')
+	})
+})
+
+describe('internal preset building blocks', () => {
+	it('nests logicIf with conditions, an actionGroup, and elseActions (type-level)', () => {
+		const preset: CompanionSimplePresetDefinition<TestManifest> = {
+			type: 'simple',
+			name: 'If',
+			style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'internal:logicIf',
+							options: {},
+							children: {
+								condition: [
+									{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } },
+									// logicOperator used as a nested condition carries no style
+									{
+										feedbackId: 'internal:logicOperator',
+										options: { operation: 'or' },
+										children: { default: [{ feedbackId: 'myFeedback', options: { bar: 1 } }] },
+									},
+								],
+								actions: [
+									{
+										actionId: 'internal:actionGroup',
+										options: { executionMode: 'concurrent' },
+										children: { default: [{ actionId: 'internal:wait', options: { time: 100 } }] },
+									},
+								],
+								elseActions: [{ actionId: 'internal:customLog', options: { message: 'no' } }],
+							},
+						},
+					],
+					up: [],
+				},
+			],
+			feedbacks: [],
+		}
+		expect(preset.steps[0].down).toHaveLength(1)
+	})
+
+	it('allows logicWhile without the optional elseActions group, and logicOperator as a styled feedback (type-level)', () => {
+		const preset: CompanionSimplePresetDefinition<TestManifest> = {
+			type: 'simple',
+			name: 'While',
+			style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'internal:logicWhile',
+							options: {},
+							children: {
+								condition: [{ feedbackId: 'internal:checkExpression', options: { expression: 'x' } }],
+								actions: [{ actionId: 'internal:wait', options: { time: 10 } }],
+							},
+						},
+					],
+					up: [],
+				},
+			],
+			feedbacks: [
+				// logicOperator as a top-level simple feedback carries a style
+				{
+					feedbackId: 'internal:logicOperator',
+					options: { operation: 'and' },
+					children: { default: [{ feedbackId: 'myFeedback', options: { bar: 1 } }] },
+					style: { bgcolor: 0x00ff00 },
+				},
+			],
+		}
+		expect(preset.steps[0].down).toHaveLength(1)
+	})
+
+	it('rejects a non-boolean feedback used as a condition (type-level)', () => {
+		const preset: CompanionSimplePresetDefinition<TestManifest> = {
+			type: 'simple',
+			name: 'BadCond',
+			style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'internal:logicIf',
+							options: {},
+							children: {
+								condition: [
+									// @ts-expect-error an advanced feedback cannot be used as a boolean condition
+									{ feedbackId: 'myAdvanced', options: {} },
+								],
+								actions: [],
+							},
+						},
+					],
+					up: [],
+				},
+			],
+			feedbacks: [],
+		}
+		expect(preset.name).toBe('BadCond')
+	})
+
+	it('nests building blocks in a layered preset (logicOperator with styleOverrides) (type-level)', () => {
+		const preset: CompanionLayeredButtonPresetDefinition<TestManifest> = {
+			type: 'layered',
+			name: 'Layered',
+			elements: [{ type: 'box', id: 'el1' }],
+			feedbacks: [
+				{
+					feedbackId: 'internal:logicOperator',
+					options: { operation: 'xor' },
+					children: { default: [{ feedbackId: 'internal:checkExpression', options: { expression: '1' } }] },
+					styleOverrides: [],
+				},
+			],
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'internal:logicWhile',
+							options: {},
+							children: {
+								condition: [{ feedbackId: 'myFeedback', options: { bar: 2 } }],
+								actions: [{ actionId: 'internal:wait', options: { time: 5 } }],
+							},
+						},
+					],
+					up: [],
+				},
+			],
+		}
+		expect(preset.feedbacks).toHaveLength(1)
 	})
 })

--- a/packages/base/src/module-api/preset/definition-graphics.ts
+++ b/packages/base/src/module-api/preset/definition-graphics.ts
@@ -5,9 +5,11 @@ import type { ButtonGraphicsCanvasElement, SomeButtonGraphicsElement } from '../
 import type { CompanionOptionValues, ExpressionOrValue } from '../input.js'
 import type {
 	CompanionButtonStepActions,
+	CompanionInternalLogicFeedbackSchemas,
 	CompanionPresetDefinitionBase,
 	CompanionPresetLocalVariable,
 	CompanionPresetOptionValues,
+	MapChildren,
 	WithInternalFeedbacks,
 } from './definition.js'
 
@@ -27,7 +29,7 @@ export interface CompanionLayeredButtonPresetDefinition<
 	/** Options for this preset */
 	options?: CompanionLayeredButtonPresetDefinitionOptions
 	/** The feedbacks on the button */
-	feedbacks: CompanionPresetLayeredFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>[]
+	feedbacks: SomePresetLayeredFeedbackEntry<TManifest>[]
 	steps: CompanionButtonStepActions<TManifest>[]
 
 	/** Local variables on this button */
@@ -80,3 +82,23 @@ export interface CompanionPresetFeedbackStyleOverride {
 	// Note: When overriding advanced feedbacks, this should be set to `{ isExpression: false, value: 'color' }` or similar to indicate which property it is using
 	override: ExpressionOrValue<JsonValue | undefined>
 }
+
+/**
+ * A building-block feedback used at the top level of a layered preset (carries element style overrides).
+ * The layered counterpart of `CompanionInternalSimpleLogicFeedback`.
+ */
+export type CompanionInternalLayeredLogicFeedback<TManifest extends InstanceTypes> = {
+	[K in keyof CompanionInternalLogicFeedbackSchemas]: {
+		feedbackId: K
+		options: CompanionPresetOptionValues<CompanionInternalLogicFeedbackSchemas[K]['options']>
+		children: MapChildren<CompanionInternalLogicFeedbackSchemas[K]['children'], TManifest>
+		styleOverrides: CompanionPresetFeedbackStyleOverride[]
+		isInverted?: boolean
+		headline?: string
+	}
+}[keyof CompanionInternalLogicFeedbackSchemas]
+
+/** A feedback entry on a layered preset: the module's own or internal feedbacks, plus internal building blocks. */
+export type SomePresetLayeredFeedbackEntry<TManifest extends InstanceTypes = InstanceTypes> =
+	| CompanionPresetLayeredFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>
+	| CompanionInternalLayeredLogicFeedback<TManifest>

--- a/packages/base/src/module-api/preset/definition-graphics.ts
+++ b/packages/base/src/module-api/preset/definition-graphics.ts
@@ -8,6 +8,7 @@ import type {
 	CompanionPresetDefinitionBase,
 	CompanionPresetLocalVariable,
 	CompanionPresetOptionValues,
+	WithInternalFeedbacks,
 } from './definition.js'
 
 /**
@@ -26,7 +27,7 @@ export interface CompanionLayeredButtonPresetDefinition<
 	/** Options for this preset */
 	options?: CompanionLayeredButtonPresetDefinitionOptions
 	/** The feedbacks on the button */
-	feedbacks: CompanionPresetLayeredFeedback<TManifest['feedbacks']>[]
+	feedbacks: CompanionPresetLayeredFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>[]
 	steps: CompanionButtonStepActions<TManifest>[]
 
 	/** Local variables on this button */

--- a/packages/base/src/module-api/preset/definition.ts
+++ b/packages/base/src/module-api/preset/definition.ts
@@ -1,3 +1,8 @@
+import type {
+	Equal,
+	Expect,
+	// eslint-disable-next-line n/no-missing-import
+} from 'type-testing'
 import type { JsonValue } from '../../common/json-value.js'
 import type { CompanionActionSchemaWithoutResult, CompanionActionSchemaWithResult } from '../action.js'
 import type { InstanceTypes } from '../base.js'
@@ -6,7 +11,11 @@ import type { CompanionOptionValues, ExpressionOrValue } from '../input.js'
 import type { CompanionButtonStyleProps } from '../style.js'
 import type { CompanionVariableValue } from '../variable.js'
 import type { CompanionLayeredButtonPresetDefinition } from './definition-graphics.js'
-import type { CompanionInternalActionSchemas, CompanionInternalFeedbackSchemas } from './internal-catalog.js'
+import type {
+	CompanionInternalActionSchemas,
+	CompanionInternalFeedbackSchemas,
+	InternalPresetBuildingBlockId,
+} from './internal-catalog.js'
 
 /**
  * Merge the reserved `internal:*` action schemas into a module's action manifest, so that presets may
@@ -16,6 +25,133 @@ import type { CompanionInternalActionSchemas, CompanionInternalFeedbackSchemas }
 export type WithInternalActions<TActionManifest> = TActionManifest & CompanionInternalActionSchemas
 /** As {@link WithInternalActions}, but for the internal feedback schemas. */
 export type WithInternalFeedbacks<TFeedbackManifest> = TFeedbackManifest & CompanionInternalFeedbackSchemas
+
+// ─── Internal building-block (logic/flow) preset entries ───────────────────────────────────────
+// Building blocks nest other actions/feedbacks via child groups, so they carry a `children` field and
+// are kept separate from the flat internal schemas (CompanionInternal{Action,Feedback}Schemas). Each
+// block is described once in a schema record (id -> options + named child-group kinds); the mapped
+// types below generate the entries, adding the common props (delay/headline/style/...) a single time.
+
+/** The kind of entries a building block's child group holds */
+export type ChildGroupKind = 'actions' | 'conditions'
+
+/** Expand a single child-group kind to its entry-array type */
+type ChildArray<TKind, TManifest extends InstanceTypes> =
+	NonNullable<TKind> extends 'conditions' ? SomePresetConditionEntry<TManifest>[] : SomePresetActionEntry<TManifest>[]
+
+/**
+ * Expand a record of named child groups to the concrete `children` shape.
+ * Homomorphic over `TGroups`, so optional groups (e.g. `elseActions?`) keep their optional modifier.
+ */
+export type MapChildren<TGroups extends Record<string, ChildGroupKind | undefined>, TManifest extends InstanceTypes> = {
+	[G in keyof TGroups]: ChildArray<TGroups[G], TManifest>
+}
+
+/** Describes each building-block action: its options and named child groups (by kind). */
+export interface CompanionInternalLogicActionSchemas {
+	/** Execute a group of actions */
+	'internal:actionGroup': {
+		options: { executionMode?: 'inherit' | 'concurrent' | 'sequential' }
+		children: { default: 'actions' }
+	}
+	/** Execute actions when all conditions are true, otherwise the (optional) else actions */
+	'internal:logicIf': {
+		options: Record<string, never>
+		children: { condition: 'conditions'; actions: 'actions'; elseActions?: 'actions' }
+	}
+	/** Repeat actions while all conditions are true */
+	'internal:logicWhile': {
+		options: Record<string, never>
+		children: { condition: 'conditions'; actions: 'actions' }
+	}
+}
+
+/** A building-block action entry (one per id in {@link CompanionInternalLogicActionSchemas}). */
+export type CompanionInternalLogicAction<TManifest extends InstanceTypes> = {
+	[K in keyof CompanionInternalLogicActionSchemas]: {
+		actionId: K
+		options: CompanionPresetOptionValues<CompanionInternalLogicActionSchemas[K]['options']>
+		children: MapChildren<CompanionInternalLogicActionSchemas[K]['children'], TManifest>
+		delay?: number
+		headline?: string
+	}
+}[keyof CompanionInternalLogicActionSchemas]
+
+/** Describes each building-block feedback: its options and named child groups (by kind). */
+export interface CompanionInternalLogicFeedbackSchemas {
+	/** Combine multiple conditions with a boolean operator */
+	'internal:logicOperator': {
+		options: { operation: 'and' | 'or' | 'xor' }
+		children: { default: 'conditions' }
+	}
+}
+
+/** A building-block feedback used as a condition (no style). */
+export type CompanionInternalConditionFeedback<TManifest extends InstanceTypes> = {
+	[K in keyof CompanionInternalLogicFeedbackSchemas]: {
+		feedbackId: K
+		options: CompanionPresetOptionValues<CompanionInternalLogicFeedbackSchemas[K]['options']>
+		children: MapChildren<CompanionInternalLogicFeedbackSchemas[K]['children'], TManifest>
+		isInverted?: boolean
+		headline?: string
+	}
+}[keyof CompanionInternalLogicFeedbackSchemas]
+
+/** A building-block feedback used at the top level of a simple preset (carries a boolean style). */
+export type CompanionInternalSimpleLogicFeedback<TManifest extends InstanceTypes> = {
+	[K in keyof CompanionInternalLogicFeedbackSchemas]: {
+		feedbackId: K
+		options: CompanionPresetOptionValues<CompanionInternalLogicFeedbackSchemas[K]['options']>
+		children: MapChildren<CompanionInternalLogicFeedbackSchemas[K]['children'], TManifest>
+		style: CompanionFeedbackButtonStyleResult
+		isInverted?: boolean
+		headline?: string
+	}
+}[keyof CompanionInternalLogicFeedbackSchemas]
+
+/**
+ * A boolean feedback used as a condition: no style, and (for concrete manifests) strictly boolean ids
+ * only — non-boolean ids resolve to `never` and drop out. Loosely-typed manifests (string index) get a
+ * permissive shape instead of collapsing to `never`.
+ */
+export type CompanionPresetConditionFeedback<
+	TFeedbackManifest extends Record<string, CompanionFeedbackSchema<CompanionOptionValues>>,
+> = string extends keyof TFeedbackManifest
+	? { feedbackId: string; options: CompanionOptionValues; isInverted?: boolean; headline?: string }
+	: {
+			[K in keyof TFeedbackManifest]: TFeedbackManifest[K]['type'] extends 'boolean'
+				? {
+						feedbackId: K
+						options: CompanionPresetOptionValues<TFeedbackManifest[K]['options']>
+						isInverted?: boolean
+						headline?: string
+					}
+				: never
+		}[keyof TFeedbackManifest]
+
+/** An action entry in a preset: the module's own or internal flat actions, plus internal building blocks. */
+export type SomePresetActionEntry<TManifest extends InstanceTypes = InstanceTypes> =
+	| CompanionPresetAction<WithInternalActions<TManifest['actions']>>
+	| CompanionInternalLogicAction<TManifest>
+
+/** A condition entry (boolean feedback or nested logic operator) used inside a building block. */
+export type SomePresetConditionEntry<TManifest extends InstanceTypes = InstanceTypes> =
+	| CompanionPresetConditionFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>
+	| CompanionInternalConditionFeedback<TManifest>
+
+/** A feedback entry on a simple preset: the module's own or internal feedbacks, plus internal building blocks. */
+export type SomePresetSimpleFeedbackEntry<TManifest extends InstanceTypes = InstanceTypes> =
+	| CompanionPresetFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>
+	| CompanionInternalSimpleLogicFeedback<TManifest>
+
+// Drift guard: the building-block schema records here must cover exactly the ids that the version map
+// in internal-catalog.ts gates (InternalPresetBuildingBlockId). If they fall out of sync, this fails.
+type _AssertBuildingBlockIds = Expect<
+	Equal<
+		keyof CompanionInternalLogicActionSchemas | keyof CompanionInternalLogicFeedbackSchemas,
+		InternalPresetBuildingBlockId
+	>
+>
 
 /**
  * The definitions of a group of presets
@@ -65,7 +201,7 @@ export interface CompanionSimplePresetDefinition<
 	steps: CompanionButtonStepActions<TManifest>[]
 
 	/** The feedbacks on the button */
-	feedbacks: CompanionPresetFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>[]
+	feedbacks: SomePresetSimpleFeedbackEntry<TManifest>[]
 
 	/** Local variables on this button */
 	localVariables?: CompanionSimplePresetLocalVariable[]
@@ -81,7 +217,7 @@ export interface CompanionSimplePresetOptions {
 
 export interface CompanionPresetActionsWithOptions<TManifest extends InstanceTypes = InstanceTypes> {
 	options?: CompanionActionSetOptions
-	actions: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
+	actions: SomePresetActionEntry<TManifest>[]
 }
 export interface CompanionActionSetOptions {
 	/**
@@ -95,25 +231,23 @@ export interface CompanionButtonStepActions<TManifest extends InstanceTypes = In
 	name?: string
 
 	/** The button down actions */
-	down: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
+	down: SomePresetActionEntry<TManifest>[]
 	/**
 	 * The button up actions
 	 * If any delay groups are defined, this becomes the short-press actions
 	 */
-	up: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
+	up: SomePresetActionEntry<TManifest>[]
 
 	/** The button rotate left actions */
-	rotate_left?: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
+	rotate_left?: SomePresetActionEntry<TManifest>[]
 	/** The button rotate right actions */
-	rotate_right?: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
+	rotate_right?: SomePresetActionEntry<TManifest>[]
 
 	/**
 	 * Long-press action groups
 	 * Keyed by the duration (in milliseconds) after which the long-press actions should be executed
 	 */
-	[duration: number]:
-		| CompanionPresetActionsWithOptions<TManifest>
-		| CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
+	[duration: number]: CompanionPresetActionsWithOptions<TManifest> | SomePresetActionEntry<TManifest>[]
 }
 
 /**

--- a/packages/base/src/module-api/preset/definition.ts
+++ b/packages/base/src/module-api/preset/definition.ts
@@ -6,6 +6,16 @@ import type { CompanionOptionValues, ExpressionOrValue } from '../input.js'
 import type { CompanionButtonStyleProps } from '../style.js'
 import type { CompanionVariableValue } from '../variable.js'
 import type { CompanionLayeredButtonPresetDefinition } from './definition-graphics.js'
+import type { CompanionInternalActionSchemas, CompanionInternalFeedbackSchemas } from './internal-catalog.js'
+
+/**
+ * Merge the reserved `internal:*` action schemas into a module's action manifest, so that presets may
+ * reference Companion's built-in internal actions alongside the module's own.
+ * The intersection merges the records: `keyof (A & B) = keyof A | keyof B`.
+ */
+export type WithInternalActions<TActionManifest> = TActionManifest & CompanionInternalActionSchemas
+/** As {@link WithInternalActions}, but for the internal feedback schemas. */
+export type WithInternalFeedbacks<TFeedbackManifest> = TFeedbackManifest & CompanionInternalFeedbackSchemas
 
 /**
  * The definitions of a group of presets
@@ -55,7 +65,7 @@ export interface CompanionSimplePresetDefinition<
 	steps: CompanionButtonStepActions<TManifest>[]
 
 	/** The feedbacks on the button */
-	feedbacks: CompanionPresetFeedback<TManifest['feedbacks']>[]
+	feedbacks: CompanionPresetFeedback<WithInternalFeedbacks<TManifest['feedbacks']>>[]
 
 	/** Local variables on this button */
 	localVariables?: CompanionSimplePresetLocalVariable[]
@@ -71,7 +81,7 @@ export interface CompanionSimplePresetOptions {
 
 export interface CompanionPresetActionsWithOptions<TManifest extends InstanceTypes = InstanceTypes> {
 	options?: CompanionActionSetOptions
-	actions: CompanionPresetAction<TManifest['actions']>[]
+	actions: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
 }
 export interface CompanionActionSetOptions {
 	/**
@@ -85,23 +95,25 @@ export interface CompanionButtonStepActions<TManifest extends InstanceTypes = In
 	name?: string
 
 	/** The button down actions */
-	down: CompanionPresetAction<TManifest['actions']>[]
+	down: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
 	/**
 	 * The button up actions
 	 * If any delay groups are defined, this becomes the short-press actions
 	 */
-	up: CompanionPresetAction<TManifest['actions']>[]
+	up: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
 
 	/** The button rotate left actions */
-	rotate_left?: CompanionPresetAction<TManifest['actions']>[]
+	rotate_left?: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
 	/** The button rotate right actions */
-	rotate_right?: CompanionPresetAction<TManifest['actions']>[]
+	rotate_right?: CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
 
 	/**
 	 * Long-press action groups
 	 * Keyed by the duration (in milliseconds) after which the long-press actions should be executed
 	 */
-	[duration: number]: CompanionPresetActionsWithOptions<TManifest> | CompanionPresetAction<TManifest['actions']>[]
+	[duration: number]:
+		| CompanionPresetActionsWithOptions<TManifest>
+		| CompanionPresetAction<WithInternalActions<TManifest['actions']>>[]
 }
 
 /**

--- a/packages/base/src/module-api/preset/internal-catalog.ts
+++ b/packages/base/src/module-api/preset/internal-catalog.ts
@@ -1,0 +1,104 @@
+import type {
+	Equal,
+	Expect,
+	// eslint-disable-next-line n/no-missing-import
+} from 'type-testing'
+import type { JsonValue } from '../../common/json-value.js'
+import type { CompanionActionSchemaWithoutResult, CompanionActionSchemaWithResult } from '../action.js'
+import type { CompanionFeedbackSchema } from '../feedback.js'
+import type { CompanionOptionValues } from '../input.js'
+
+/**
+ * Companion's built-in "internal" actions that may be referenced from a module's presets.
+ *
+ * These are exposed under reserved `internal:*` ids which are merged into the preset action manifest,
+ * so they can be used alongside a module's own actions in presets. Companion translates each of these
+ * to the matching internal action when a preset is imported onto a control, resolving any references
+ * (such as the button location) to the control the preset is placed on.
+ *
+ * This list is deliberately small and self-scoped; it can grow over future api versions. When adding
+ * a new entry, also add it to {@link INTERNAL_PRESET_MIN_API_VERSION}.
+ */
+export type CompanionInternalActionSchemas = {
+	/** Wait for a specified amount of time */
+	'internal:wait': { options: { time: number } }
+	/** Write a message to the Companion log */
+	'internal:customLog': { options: { message: string } }
+	/** Abort the actions currently running on this button */
+	'internal:abortButton': { options: { skipReleaseActions?: boolean } }
+	/** Set the value of one of this button's local variables */
+	'internal:localVariableSet': { options: { name: string; value: string } }
+}
+
+/**
+ * Companion's built-in "internal" feedbacks that may be referenced from a module's presets.
+ *
+ * As with {@link CompanionInternalActionSchemas}, these are exposed under reserved `internal:*` ids and
+ * translated by Companion at preset import time. The `type` of each feedback drives whether a `style`
+ * (and `isInverted`) is required when used in a preset, exactly as for a module's own feedbacks.
+ *
+ * When adding a new entry, also add it to {@link INTERNAL_PRESET_MIN_API_VERSION}.
+ */
+export type CompanionInternalFeedbackSchemas = {
+	/** Change style based on a boolean expression */
+	'internal:checkExpression': { type: 'boolean'; options: { expression: string } }
+	/** Change style when this button is being pressed */
+	'internal:buttonPushed': { type: 'boolean'; options: { treatSteppedAsPressed?: boolean } }
+	/** Change style based on the current step of this button */
+	'internal:buttonCurrentStep': { type: 'boolean'; options: { step: number } }
+}
+
+/**
+ * The minimum module api version required to use each internal preset action/feedback id.
+ *
+ * The host uses this to drop (with a warning) any internal preset entry that a module is too old to be
+ * allowed to use. This lets the catalog above grow over future api versions without ever letting an
+ * older module emit an id it predates.
+ */
+export const INTERNAL_PRESET_MIN_API_VERSION: Record<
+	keyof CompanionInternalActionSchemas | keyof CompanionInternalFeedbackSchemas,
+	string
+> = {
+	'internal:wait': '2.1.0-0',
+	'internal:customLog': '2.1.0-0',
+	'internal:abortButton': '2.1.0-0',
+	'internal:localVariableSet': '2.1.0-0',
+	'internal:checkExpression': '2.1.0-0',
+	'internal:buttonPushed': '2.1.0-0',
+	'internal:buttonCurrentStep': '2.1.0-0',
+}
+
+// --- Type-level assertions ---------------------------------------------------------------------
+// Ensure the catalog interfaces above are valid action/feedback schema records, so that they can be
+// merged into the preset manifest types. A missing `type`, a bad `type` literal, or a non-JsonValue
+// option will cause one of these to fail to compile.
+
+type _AssertActionSchemas = Expect<
+	Equal<
+		CompanionInternalActionSchemas extends Record<
+			string,
+			| CompanionActionSchemaWithoutResult<CompanionOptionValues>
+			| CompanionActionSchemaWithResult<CompanionOptionValues, JsonValue>
+		>
+			? true
+			: false,
+		true
+	>
+>
+
+type _AssertFeedbackSchemas = Expect<
+	Equal<
+		CompanionInternalFeedbackSchemas extends Record<string, CompanionFeedbackSchema<CompanionOptionValues>>
+			? true
+			: false,
+		true
+	>
+>
+
+// Ensure the version map covers exactly the catalog ids (no missing or stray entries).
+type _AssertVersionMapKeys = Expect<
+	Equal<
+		keyof typeof INTERNAL_PRESET_MIN_API_VERSION,
+		keyof CompanionInternalActionSchemas | keyof CompanionInternalFeedbackSchemas
+	>
+>

--- a/packages/base/src/module-api/preset/internal-catalog.ts
+++ b/packages/base/src/module-api/preset/internal-catalog.ts
@@ -49,6 +49,19 @@ export type CompanionInternalFeedbackSchemas = {
 }
 
 /**
+ * The reserved ids for the internal "building block" (logic/flow) actions and feedbacks. These nest
+ * other entries via child groups, so unlike the flat catalog above they are not expressed as schema
+ * records here; their full types live in the preset definition files. This union exists so the version
+ * map below stays exhaustive, and is cross-checked against those types (see the drift-guard type-test in
+ * definition.ts).
+ */
+export type InternalPresetBuildingBlockId =
+	| 'internal:actionGroup'
+	| 'internal:logicIf'
+	| 'internal:logicWhile'
+	| 'internal:logicOperator'
+
+/**
  * The minimum module api version required to use each internal preset action/feedback id.
  *
  * The host uses this to drop (with a warning) any internal preset entry that a module is too old to be
@@ -56,7 +69,7 @@ export type CompanionInternalFeedbackSchemas = {
  * older module emit an id it predates.
  */
 export const INTERNAL_PRESET_MIN_API_VERSION: Record<
-	keyof CompanionInternalActionSchemas | keyof CompanionInternalFeedbackSchemas,
+	keyof CompanionInternalActionSchemas | keyof CompanionInternalFeedbackSchemas | InternalPresetBuildingBlockId,
 	string
 > = {
 	'internal:wait': '2.1.0-0',
@@ -66,6 +79,10 @@ export const INTERNAL_PRESET_MIN_API_VERSION: Record<
 	'internal:checkExpression': '2.1.0-0',
 	'internal:buttonPushed': '2.1.0-0',
 	'internal:buttonCurrentStep': '2.1.0-0',
+	'internal:actionGroup': '2.1.0-0',
+	'internal:logicIf': '2.1.0-0',
+	'internal:logicWhile': '2.1.0-0',
+	'internal:logicOperator': '2.1.0-0',
 }
 
 // --- Type-level assertions ---------------------------------------------------------------------
@@ -99,6 +116,6 @@ type _AssertFeedbackSchemas = Expect<
 type _AssertVersionMapKeys = Expect<
 	Equal<
 		keyof typeof INTERNAL_PRESET_MIN_API_VERSION,
-		keyof CompanionInternalActionSchemas | keyof CompanionInternalFeedbackSchemas
+		keyof CompanionInternalActionSchemas | keyof CompanionInternalFeedbackSchemas | InternalPresetBuildingBlockId
 	>
 >

--- a/packages/base/src/module-api/preset/main.ts
+++ b/packages/base/src/module-api/preset/main.ts
@@ -1,3 +1,4 @@
 export * from './definition.js'
 export * from './definition-graphics.js'
+export * from './internal-catalog.js'
 export * from './structure.js'

--- a/packages/host/src/instance.ts
+++ b/packages/host/src/instance.ts
@@ -122,7 +122,13 @@ export class InstanceWrapper<TManifest extends InstanceTypes> {
 			},
 
 			setPresetDefinitions: (structure, presets) => {
-				const sanitised = sanitisePresetDefinitions(this.#actionManager, this.#feedbackManager, structure, presets)
+				const sanitised = sanitisePresetDefinitions(
+					this.#actionManager,
+					this.#feedbackManager,
+					structure,
+					presets,
+					moduleApiVersion,
+				)
 				this.#host.setPresetDefinitions(sanitised.structure, sanitised.presets)
 			},
 			setCompositeElementDefinitions: (compositeElements) => {

--- a/packages/host/src/internal/__tests__/actions.spec.ts
+++ b/packages/host/src/internal/__tests__/actions.spec.ts
@@ -164,6 +164,20 @@ describe('ActionManager', () => {
 				'Action id "__proto__" is a reserved word',
 			)
 		})
+
+		it('throws for ids with the internal prefix', () => {
+			const { manager } = createManager()
+
+			const mockDefinition: CompanionActionDefinition = {
+				name: 'Definition0',
+				options: [],
+				callback: vi.fn(),
+			}
+
+			expect(() => manager.setActionDefinitions({ 'internal:foo': mockDefinition })).toThrow(
+				'Action id "internal:foo" uses the reserved "internal:" prefix',
+			)
+		})
 	})
 
 	describe('set definitions: deprecation warnings', () => {

--- a/packages/host/src/internal/__tests__/presets.spec.ts
+++ b/packages/host/src/internal/__tests__/presets.spec.ts
@@ -62,9 +62,10 @@ function run(
 	actions: Record<string, CompanionActionDefinition> = {},
 	feedbacks: Record<string, CompanionBooleanFeedbackDefinition<CompanionOptionValues>> = {},
 	structure: CompanionPresetSection<InstanceTypes>[] = NO_STRUCTURE,
+	moduleApiVersion = '2.1.0',
 ): ReturnType<typeof sanitisePresetDefinitions> {
 	const { actionsManager, feedbacksManager } = makeManagers(actions, feedbacks)
-	return sanitisePresetDefinitions(actionsManager, feedbacksManager, structure, presets)
+	return sanitisePresetDefinitions(actionsManager, feedbacksManager, structure, presets, moduleApiVersion)
 }
 
 function validSimple(
@@ -120,6 +121,7 @@ function runCapture(
 	actions: Record<string, CompanionActionDefinition> = {},
 	feedbacks: Record<string, CompanionBooleanFeedbackDefinition<CompanionOptionValues>> = {},
 	structure: CompanionPresetSection<InstanceTypes>[] = NO_STRUCTURE,
+	moduleApiVersion = '2.1.0',
 ): string[] {
 	const messages: string[] = []
 	const prev = global.COMPANION_LOGGER
@@ -127,7 +129,7 @@ function runCapture(
 		if (level === 'warn') messages.push(message)
 	}
 	try {
-		run(presets, actions, feedbacks, structure)
+		run(presets, actions, feedbacks, structure, moduleApiVersion)
 	} finally {
 		global.COMPANION_LOGGER = prev
 	}
@@ -140,6 +142,7 @@ function runSanitise(
 	actions: Record<string, CompanionActionDefinition> = {},
 	feedbacks: Record<string, CompanionBooleanFeedbackDefinition<CompanionOptionValues>> = {},
 	structure: CompanionPresetSection<InstanceTypes>[] = NO_STRUCTURE,
+	moduleApiVersion = '2.1.0',
 ): { result: ReturnType<typeof sanitisePresetDefinitions>; msgs: string[] } {
 	const msgs: string[] = []
 	const prev = global.COMPANION_LOGGER
@@ -148,7 +151,7 @@ function runSanitise(
 	}
 	let result: ReturnType<typeof sanitisePresetDefinitions>
 	try {
-		result = run(presets, actions, feedbacks, structure)
+		result = run(presets, actions, feedbacks, structure, moduleApiVersion)
 	} finally {
 		global.COMPANION_LOGGER = prev
 	}
@@ -683,6 +686,68 @@ describe('validatePresetDefinitions', () => {
 			const structure = structureFor('p1')
 			const { result } = runSanitise({ p1: validSimple() }, {}, {}, structure)
 			expect(result.structure).toStrictEqual(structure)
+		})
+	})
+
+	describe('internal action/feedback references', () => {
+		it('forwards an allowed internal action without flagging it as unknown', () => {
+			const presets = {
+				p1: validSimple({
+					steps: [{ down: [{ actionId: 'internal:wait', options: { time: 500 } }], up: [] }],
+				}),
+			} as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('unknown action definitions'))).toBe(false)
+			expect(msgs.some((m) => m.includes('have been removed'))).toBe(false)
+			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
+			expect(returned.steps[0].down).toHaveLength(1)
+		})
+
+		it('forwards an allowed internal feedback without flagging it as unknown', () => {
+			const presets = {
+				p1: validSimple({
+					feedbacks: [{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' }, style: {} }],
+				}),
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('unknown feedback definitions'))).toBe(false)
+			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
+			expect(returned.feedbacks).toHaveLength(1)
+		})
+
+		it('drops an internal action the module is too old to use, and warns', () => {
+			const presets = {
+				p1: validSimple({
+					steps: [{ down: [{ actionId: 'internal:wait', options: { time: 500 } }], up: [] }],
+				}),
+			} as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'), '2.0.0')
+			expect(msgs.some((m) => m.includes('have been removed') && m.includes('My Preset'))).toBe(true)
+			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
+			expect(returned.steps[0].down).toHaveLength(0)
+		})
+
+		it('drops an unknown internal id regardless of version, and warns', () => {
+			const presets = {
+				p1: validSimple({
+					feedbacks: [{ feedbackId: 'internal:nonexistent', options: {}, style: {} }],
+				}),
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('have been removed'))).toBe(true)
+			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
+			expect(returned.feedbacks).toHaveLength(0)
+		})
+
+		it('drops disallowed internal actions in numbered delay groups too', () => {
+			const presets = {
+				p1: validSimple({
+					steps: [{ down: [], up: [], 1000: [{ actionId: 'internal:nope', options: {} }] }],
+				}),
+			} as CompanionPresetDefinitions<InstanceTypes>
+			const { result } = runSanitise(presets, {}, {}, structureFor('p1'))
+			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
+			expect((returned.steps[0] as any)[1000]).toHaveLength(0)
 		})
 	})
 })

--- a/packages/host/src/internal/__tests__/presets.spec.ts
+++ b/packages/host/src/internal/__tests__/presets.spec.ts
@@ -749,5 +749,112 @@ describe('validatePresetDefinitions', () => {
 			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
 			expect((returned.steps[0] as any)[1000]).toHaveLength(0)
 		})
+
+		it('forwards an allowed building block and keeps its allowed internal children', () => {
+			const presets = {
+				p1: {
+					type: 'simple',
+					name: 'My Preset',
+					style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+					feedbacks: [],
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'internal:logicIf',
+									options: {},
+									children: {
+										condition: [{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } }],
+										actions: [{ actionId: 'internal:wait', options: { time: 1 } }],
+									},
+								},
+							],
+							up: [],
+						},
+					],
+				},
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('have been removed'))).toBe(false)
+			const block = (result.presets['p1'] as any).steps[0].down[0]
+			expect(block.children.actions).toHaveLength(1)
+			expect(block.children.condition).toHaveLength(1)
+		})
+
+		it('drops a disallowed internal entry nested inside a building block child group, and warns', () => {
+			const presets = {
+				p1: {
+					type: 'simple',
+					name: 'My Preset',
+					style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+					feedbacks: [],
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'internal:logicIf',
+									options: {},
+									children: {
+										condition: [{ feedbackId: 'internal:checkExpression', options: { expression: '1 > 0' } }],
+										actions: [
+											{ actionId: 'internal:wait', options: { time: 1 } },
+											{ actionId: 'internal:nope', options: {} },
+										],
+									},
+								},
+							],
+							up: [],
+						},
+					],
+				},
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('have been removed') && m.includes('My Preset'))).toBe(true)
+			const block = (result.presets['p1'] as any).steps[0].down[0]
+			expect(block.children.actions).toHaveLength(1)
+			expect(block.children.actions[0].actionId).toBe('internal:wait')
+		})
+
+		it('drops a disallowed internal entry nested two levels deep', () => {
+			const presets = {
+				p1: {
+					type: 'simple',
+					name: 'My Preset',
+					style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+					feedbacks: [],
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'internal:logicIf',
+									options: {},
+									children: {
+										condition: [],
+										actions: [
+											{
+												actionId: 'internal:actionGroup',
+												options: {},
+												children: {
+													default: [
+														{ actionId: 'internal:nope', options: {} },
+														{ actionId: 'internal:wait', options: { time: 1 } },
+													],
+												},
+											},
+										],
+									},
+								},
+							],
+							up: [],
+						},
+					],
+				},
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('have been removed'))).toBe(true)
+			const group = (result.presets['p1'] as any).steps[0].down[0].children.actions[0]
+			expect(group.children.default).toHaveLength(1)
+			expect(group.children.default[0].actionId).toBe('internal:wait')
+		})
 	})
 })

--- a/packages/host/src/internal/__tests__/presets.spec.ts
+++ b/packages/host/src/internal/__tests__/presets.spec.ts
@@ -693,14 +693,22 @@ describe('validatePresetDefinitions', () => {
 		it('forwards an allowed internal action without flagging it as unknown', () => {
 			const presets = {
 				p1: validSimple({
-					steps: [{ down: [{ actionId: 'internal:wait', options: { time: 500 } }], up: [] }],
+					steps: [
+						{
+							down: [
+								{ actionId: 'internal:wait', options: { time: 500 } },
+								{ actionId: 'my-action', options: { opt1: 'val' } },
+							],
+							up: [],
+						},
+					],
 				}),
 			} as CompanionPresetDefinitions<InstanceTypes>
-			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
+			const { result, msgs } = runSanitise(presets, { 'my-action': makeActionDef('opt1') }, {}, structureFor('p1'))
 			expect(msgs.some((m) => m.includes('unknown action definitions'))).toBe(false)
 			expect(msgs.some((m) => m.includes('have been removed'))).toBe(false)
 			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
-			expect(returned.steps[0].down).toHaveLength(1)
+			expect(returned.steps[0].down.map((a) => a.actionId)).toEqual(['internal:wait', 'my-action'])
 		})
 
 		it('forwards an allowed internal feedback without flagging it as unknown', () => {
@@ -712,7 +720,7 @@ describe('validatePresetDefinitions', () => {
 			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
 			expect(msgs.some((m) => m.includes('unknown feedback definitions'))).toBe(false)
 			const returned = result.presets['p1'] as CompanionSimplePresetDefinition<InstanceTypes>
-			expect(returned.feedbacks).toHaveLength(1)
+			expect(returned.feedbacks.map((f) => f.feedbackId)).toEqual(['internal:checkExpression'])
 		})
 
 		it('drops an internal action the module is too old to use, and warns', () => {
@@ -777,8 +785,8 @@ describe('validatePresetDefinitions', () => {
 			const { result, msgs } = runSanitise(presets, {}, {}, structureFor('p1'))
 			expect(msgs.some((m) => m.includes('have been removed'))).toBe(false)
 			const block = (result.presets['p1'] as any).steps[0].down[0]
-			expect(block.children.actions).toHaveLength(1)
-			expect(block.children.condition).toHaveLength(1)
+			expect(block.children.actions.map((a: any) => a.actionId)).toEqual(['internal:wait'])
+			expect(block.children.condition.map((f: any) => f.feedbackId)).toEqual(['internal:checkExpression'])
 		})
 
 		it('drops a disallowed internal entry nested inside a building block child group, and warns', () => {

--- a/packages/host/src/internal/__tests__/presets.spec.ts
+++ b/packages/host/src/internal/__tests__/presets.spec.ts
@@ -865,4 +865,101 @@ describe('validatePresetDefinitions', () => {
 			expect(group.children.default[0].actionId).toBe('internal:wait')
 		})
 	})
+
+	describe('module entries nested in building-block children', () => {
+		/** A preset with a single internal:logicIf block containing the given child groups */
+		function presetWithBlockChildren(children: Record<string, unknown[]>): CompanionPresetDefinitions<InstanceTypes> {
+			return {
+				p1: {
+					type: 'simple',
+					name: 'My Preset',
+					style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+					feedbacks: [],
+					steps: [
+						{
+							down: [{ actionId: 'internal:logicIf', options: {}, children }],
+							up: [],
+						},
+					],
+				},
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+		}
+
+		it('warns for an unknown module action nested inside building-block children', () => {
+			const presets = presetWithBlockChildren({
+				condition: [],
+				actions: [{ actionId: 'missing-action', options: {} }],
+			})
+			const msgs = runCapture(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('unknown action definitions') && m.includes('My Preset'))).toBe(true)
+		})
+
+		it('warns for an unknown module feedback nested inside a condition group', () => {
+			const presets = presetWithBlockChildren({
+				condition: [{ feedbackId: 'missing-feedback', options: {} }],
+				actions: [],
+			})
+			const msgs = runCapture(presets, {}, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('unknown feedback definitions') && m.includes('My Preset'))).toBe(true)
+		})
+
+		it('warns for unknown option keys on a nested module action', () => {
+			const presets = presetWithBlockChildren({
+				condition: [],
+				actions: [{ actionId: 'my-action', options: { nope: 1 } }],
+			})
+			const msgs = runCapture(presets, { 'my-action': makeActionDef('opt1') }, {}, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('unknown action option keys') && m.includes('My Preset'))).toBe(true)
+		})
+
+		it('warns for unknown option keys on a nested module feedback', () => {
+			const presets = presetWithBlockChildren({
+				condition: [{ feedbackId: 'my-feedback', options: { nope: 1 } }],
+				actions: [],
+			})
+			const msgs = runCapture(presets, {}, { 'my-feedback': makeFeedbackDef('opt1') }, structureFor('p1'))
+			expect(msgs.some((m) => m.includes('unknown feedback option keys') && m.includes('My Preset'))).toBe(true)
+		})
+
+		it('does not warn for valid module entries nested inside building-block children', () => {
+			const presets = presetWithBlockChildren({
+				condition: [{ feedbackId: 'my-feedback', options: { opt1: 'a' } }],
+				actions: [{ actionId: 'my-action', options: { opt1: 'b' } }],
+			})
+			const msgs = runCapture(
+				presets,
+				{ 'my-action': makeActionDef('opt1') },
+				{ 'my-feedback': makeFeedbackDef('opt1') },
+				structureFor('p1'),
+			)
+			expect(msgs).toHaveLength(0)
+		})
+
+		it('does not validate the children of a dropped internal entry', () => {
+			const presets = {
+				p1: {
+					type: 'simple',
+					name: 'My Preset',
+					style: { text: '', size: 'auto', color: 0xffffff, bgcolor: 0 },
+					feedbacks: [],
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'internal:nope',
+									options: {},
+									children: { actions: [{ actionId: 'missing-action', options: {} }] },
+								},
+							],
+							up: [],
+						},
+					],
+				},
+			} as unknown as CompanionPresetDefinitions<InstanceTypes>
+			const msgs = runCapture(presets, {}, {}, structureFor('p1'))
+			// The whole block is dropped, so its children must not produce unknown-id warnings
+			expect(msgs.some((m) => m.includes('have been removed'))).toBe(true)
+			expect(msgs.some((m) => m.includes('unknown action definitions'))).toBe(false)
+		})
+	})
 })

--- a/packages/host/src/internal/actions.ts
+++ b/packages/host/src/internal/actions.ts
@@ -226,6 +226,8 @@ export class ActionManager {
 		for (const [actionId, action] of Object.entries(actions)) {
 			if (!action) continue
 			if (BANNED_PROPS.has(actionId)) throw new Error(`Action id "${actionId}" is a reserved word`)
+			if (actionId.startsWith('internal:'))
+				throw new Error(`Action id "${actionId}" uses the reserved "internal:" prefix`)
 
 			const hasSubscriptionMethods = !!action.subscribe || !!action.unsubscribe
 

--- a/packages/host/src/internal/feedback.ts
+++ b/packages/host/src/internal/feedback.ts
@@ -345,6 +345,8 @@ export class FeedbackManager {
 		for (const [feedbackId, feedback] of Object.entries(feedbacks)) {
 			if (!feedback) continue
 			if (BANNED_PROPS.has(feedbackId)) throw new Error(`Feedback id "${feedbackId}" is a reserved word`)
+			if (feedbackId.startsWith('internal:'))
+				throw new Error(`Feedback id "${feedbackId}" uses the reserved "internal:" prefix`)
 
 			hostFeedbacks.push({
 				id: feedbackId,

--- a/packages/host/src/internal/presets.ts
+++ b/packages/host/src/internal/presets.ts
@@ -13,6 +13,9 @@ import { BANNED_PROPS } from './util.js'
 
 const logger = createModuleLogger('PresetDefinitionsManager')
 
+/** Guard against pathological nesting when recursing into building-block child groups */
+const MAX_PRESET_NESTING_DEPTH = 10
+
 /** Whether an action/feedback id references one of Companion's built-in internal definitions */
 function isInternalId(id: unknown): id is string {
 	return typeof id === 'string' && id.startsWith('internal:')
@@ -69,8 +72,9 @@ export function sanitisePresetDefinitions(
 
 	/**
 	 * Drop any `internal:*` action/feedback entries the module is not allowed to use (unknown ids, or
-	 * ids the module is too old for). Allowed internal entries and all module-own entries are kept as-is.
-	 * Returns new feedbacks/steps arrays, and whether anything was dropped.
+	 * ids the module is too old for). Allowed internal entries and all module-own entries are kept as-is,
+	 * recursing into the child groups of building-block entries. Returns new feedbacks/steps arrays, and
+	 * whether anything was dropped.
 	 */
 	function dropDisallowedInternalEntries(preset: any): { feedbacks: any; steps: any; dropped: boolean } {
 		let dropped = false
@@ -80,23 +84,43 @@ export function sanitisePresetDefinitions(
 			dropped = true
 			return false
 		}
-		const filterActions = (arr: unknown): unknown => (Array.isArray(arr) ? arr.filter((a) => keep(a?.actionId)) : arr)
 
-		const feedbacks = Array.isArray(preset.feedbacks)
-			? preset.feedbacks.filter((fb: any) => keep(fb?.feedbackId))
-			: preset.feedbacks
+		/**
+		 * Recursively filter an array of action/feedback/condition entries: drop disallowed internal
+		 * entries, and filter the child groups of any building-block entry that remains.
+		 */
+		const filterEntries = (entries: unknown, depth: number): unknown => {
+			if (!Array.isArray(entries)) return entries
+			if (depth > MAX_PRESET_NESTING_DEPTH) return entries
+			const out: unknown[] = []
+			for (const entry of entries) {
+				if (!keep(entry?.actionId ?? entry?.feedbackId)) continue
+				if (entry && typeof entry === 'object' && entry.children && typeof entry.children === 'object') {
+					const children: Record<string, unknown> = {}
+					for (const [groupId, childEntries] of Object.entries(entry.children)) {
+						children[groupId] = filterEntries(childEntries, depth + 1)
+					}
+					out.push({ ...entry, children })
+				} else {
+					out.push(entry)
+				}
+			}
+			return out
+		}
+
+		const feedbacks = filterEntries(preset.feedbacks, 0)
 
 		const steps = Array.isArray(preset.steps)
 			? preset.steps.map((step: any) => {
 					const out: Record<string, unknown> = {}
 					for (const [key, value] of Object.entries(step)) {
 						if (key === 'down' || key === 'up' || key === 'rotate_left' || key === 'rotate_right') {
-							out[key] = filterActions(value)
+							out[key] = filterEntries(value, 0)
 						} else if (/^\d+$/.test(key)) {
 							if (Array.isArray(value)) {
-								out[key] = filterActions(value)
+								out[key] = filterEntries(value, 0)
 							} else if (value && typeof value === 'object' && Array.isArray((value as any).actions)) {
-								out[key] = { ...(value as any), actions: filterActions((value as any).actions) }
+								out[key] = { ...(value as any), actions: filterEntries((value as any).actions, 0) }
 							} else {
 								out[key] = value
 							}

--- a/packages/host/src/internal/presets.ts
+++ b/packages/host/src/internal/presets.ts
@@ -1,6 +1,8 @@
+import semver from 'semver'
 import { z } from 'zod'
 import {
 	createModuleLogger,
+	INTERNAL_PRESET_MIN_API_VERSION,
 	type CompanionPresetDefinitions,
 	type CompanionPresetSection,
 } from '@companion-module/base'
@@ -10,6 +12,11 @@ import type { FeedbackManager } from './feedback.js'
 import { BANNED_PROPS } from './util.js'
 
 const logger = createModuleLogger('PresetDefinitionsManager')
+
+/** Whether an action/feedback id references one of Companion's built-in internal definitions */
+function isInternalId(id: unknown): id is string {
+	return typeof id === 'string' && id.startsWith('internal:')
+}
 
 /** Collect all element IDs declared in a layered elements tree, recursing into group children */
 function collectElementIds(elements: unknown[]): Set<string> {
@@ -31,6 +38,7 @@ export function sanitisePresetDefinitions(
 	feedbacksManager: FeedbackManager,
 	structure: CompanionPresetSection<any>[],
 	presets: CompanionPresetDefinitions<any>,
+	moduleApiVersion: string,
 ): {
 	structure: CompanionPresetSection<any>[]
 	presets: CompanionPresetDefinitions<any>
@@ -46,12 +54,70 @@ export function sanitisePresetDefinitions(
 	const validActionIds = new Set(actionsManager.getDefinitionIds())
 	const validFeedbackIds = new Set(feedbacksManager.getDefinitionIds())
 
+	const validModuleApiVersion = semver.valid(moduleApiVersion, { loose: true })
+
+	/**
+	 * Whether the module is allowed to reference the given internal action/feedback id.
+	 * Unknown internal ids, or ids the module is too old to use, are not allowed and will be dropped.
+	 */
+	function isInternalIdAllowed(id: string): boolean {
+		const minApiVersion = (INTERNAL_PRESET_MIN_API_VERSION as Record<string, string | undefined>)[id]
+		if (!minApiVersion) return false
+		if (!validModuleApiVersion) return false
+		return semver.gte(validModuleApiVersion, minApiVersion, { loose: true })
+	}
+
+	/**
+	 * Drop any `internal:*` action/feedback entries the module is not allowed to use (unknown ids, or
+	 * ids the module is too old for). Allowed internal entries and all module-own entries are kept as-is.
+	 * Returns new feedbacks/steps arrays, and whether anything was dropped.
+	 */
+	function dropDisallowedInternalEntries(preset: any): { feedbacks: any; steps: any; dropped: boolean } {
+		let dropped = false
+		const keep = (id: unknown): boolean => {
+			if (!isInternalId(id)) return true
+			if (isInternalIdAllowed(id)) return true
+			dropped = true
+			return false
+		}
+		const filterActions = (arr: unknown): unknown => (Array.isArray(arr) ? arr.filter((a) => keep(a?.actionId)) : arr)
+
+		const feedbacks = Array.isArray(preset.feedbacks)
+			? preset.feedbacks.filter((fb: any) => keep(fb?.feedbackId))
+			: preset.feedbacks
+
+		const steps = Array.isArray(preset.steps)
+			? preset.steps.map((step: any) => {
+					const out: Record<string, unknown> = {}
+					for (const [key, value] of Object.entries(step)) {
+						if (key === 'down' || key === 'up' || key === 'rotate_left' || key === 'rotate_right') {
+							out[key] = filterActions(value)
+						} else if (/^\d+$/.test(key)) {
+							if (Array.isArray(value)) {
+								out[key] = filterActions(value)
+							} else if (value && typeof value === 'object' && Array.isArray((value as any).actions)) {
+								out[key] = { ...(value as any), actions: filterActions((value as any).actions) }
+							} else {
+								out[key] = value
+							}
+						} else {
+							out[key] = value
+						}
+					}
+					return out
+				})
+			: preset.steps
+
+		return { feedbacks, steps, dropped }
+	}
+
 	const presetsWithInvalidActionIds: string[] = []
 	const presetsWithInvalidFeedbackIds: string[] = []
 	const presetsWithInvalidActionOptionKeys: string[] = []
 	const presetsWithInvalidFeedbackOptionKeys: string[] = []
 	const presetsWithInvalidElements: string[] = []
 	const presetsWithInvalidStyleOverrideRefs: string[] = []
+	const presetsWithDisallowedInternalIds: string[] = []
 	const presetsFailedValidation: string[] = []
 
 	for (const [_id, preset] of Object.entries(presets)) {
@@ -108,11 +174,21 @@ export function sanitisePresetDefinitions(
 				if (hasInvalidRef) presetsWithInvalidStyleOverrideRefs.push(presetName)
 			}
 
+			// --- Drop internal:* entries the module is not allowed to reference ---
+			const internalFiltered = dropDisallowedInternalEntries(sanitisedPreset)
+			sanitisedPreset = {
+				...sanitisedPreset,
+				feedbacks: internalFiltered.feedbacks,
+				steps: internalFiltered.steps,
+			}
+			if (internalFiltered.dropped) presetsWithDisallowedInternalIds.push(presetName)
+
 			// --- Validate feedback IDs and option keys ---
 			let hasInvalidFeedback = false
 			let hasInvalidFeedbackOptionKeys = false
 			for (const feedback of preset.feedbacks) {
 				const feedbackId = feedback?.feedbackId
+				if (isInternalId(feedbackId)) continue // internal references are handled above, not validated here
 				if (!validFeedbackIds.has(feedbackId)) {
 					hasInvalidFeedback = true
 				} else {
@@ -142,6 +218,7 @@ export function sanitisePresetDefinitions(
 					if (!Array.isArray(actions)) continue
 					for (const action of actions) {
 						const actionId = action?.actionId
+						if (isInternalId(actionId)) continue // internal references are handled above, not validated here
 						if (!validActionIds.has(actionId)) {
 							hasInvalidAction = true
 						} else {
@@ -165,6 +242,7 @@ export function sanitisePresetDefinitions(
 					if (!Array.isArray(actions)) continue
 					for (const action of actions) {
 						const actionId = action?.actionId
+						if (isInternalId(actionId)) continue // internal references are handled above, not validated here
 						if (!validActionIds.has(actionId)) {
 							hasInvalidAction = true
 						} else {
@@ -222,6 +300,13 @@ export function sanitisePresetDefinitions(
 	if (presetsWithInvalidActionOptionKeys.length > 0) {
 		logger.warn(
 			`The following preset definitions reference unknown action option keys: ${presetsWithInvalidActionOptionKeys
+				.sort()
+				.join(', ')}`,
+		)
+	}
+	if (presetsWithDisallowedInternalIds.length > 0) {
+		logger.warn(
+			`The following preset definitions reference internal actions/feedbacks which are not available to this module (unknown id, or the module's api version is too old) and have been removed: ${presetsWithDisallowedInternalIds
 				.sort()
 				.join(', ')}`,
 		)

--- a/packages/host/src/internal/presets.ts
+++ b/packages/host/src/internal/presets.ts
@@ -207,83 +207,91 @@ export function sanitisePresetDefinitions(
 			}
 			if (internalFiltered.dropped) presetsWithDisallowedInternalIds.push(presetName)
 
-			// --- Validate feedback IDs and option keys ---
+			// --- Validate feedback/action IDs and option keys, recursing into building-block children ---
 			let hasInvalidFeedback = false
 			let hasInvalidFeedbackOptionKeys = false
-			for (const feedback of preset.feedbacks) {
-				const feedbackId = feedback?.feedbackId
-				if (isInternalId(feedbackId)) continue // internal references are handled above, not validated here
-				if (!validFeedbackIds.has(feedbackId)) {
-					hasInvalidFeedback = true
-				} else {
-					const def = feedbacksManager.getDefinition(feedbackId)
-					if (def && feedback.options && typeof feedback.options === 'object') {
-						const validKeys = new Set(def.options.map((f) => f.id))
-						for (const key of Object.keys(feedback.options)) {
-							if (!validKeys.has(key)) {
-								hasInvalidFeedbackOptionKeys = true
-								break
-							}
-						}
-					}
-				}
-			}
-			if (hasInvalidFeedback) presetsWithInvalidFeedbackIds.push(presetName)
-			if (hasInvalidFeedbackOptionKeys) presetsWithInvalidFeedbackOptionKeys.push(presetName)
-
-			// --- Validate action IDs and option keys across all steps ---
 			let hasInvalidAction = false
 			let hasInvalidActionOptionKeys = false
-			for (const step of preset.steps) {
-				// Check named action arrays
-				const namedKeys = ['down', 'up', 'rotate_left', 'rotate_right'] as const
-				for (const key of namedKeys) {
-					const actions = step[key]
-					if (!Array.isArray(actions)) continue
-					for (const action of actions) {
-						const actionId = action?.actionId
-						if (isInternalId(actionId)) continue // internal references are handled above, not validated here
-						if (!validActionIds.has(actionId)) {
-							hasInvalidAction = true
-						} else {
-							const def = actionsManager.getDefinition(actionId)
-							if (def && action.options && typeof action.options === 'object') {
-								const validKeys = new Set(def.options.map((f) => f.id))
-								for (const optKey of Object.keys(action.options)) {
-									if (!validKeys.has(optKey)) {
-										hasInvalidActionOptionKeys = true
-										break
-									}
-								}
-							}
-						}
+
+			const hasUnknownOptionKeys = (def: { options: Array<{ id: string }> } | undefined, options: unknown): boolean => {
+				if (!def || !options || typeof options !== 'object') return false
+				const validKeys = new Set(def.options.map((f) => f.id))
+				for (const key of Object.keys(options)) {
+					if (!validKeys.has(key)) return true
+				}
+				return false
+			}
+
+			const validateFeedbackEntry = (feedback: any, depth: number): void => {
+				const feedbackId = feedback?.feedbackId
+				// internal references are handled by the filtering above, not validated here
+				if (!isInternalId(feedbackId)) {
+					if (!validFeedbackIds.has(feedbackId)) {
+						hasInvalidFeedback = true
+					} else if (hasUnknownOptionKeys(feedbacksManager.getDefinition(feedbackId), feedback?.options)) {
+						hasInvalidFeedbackOptionKeys = true
 					}
 				}
-				// Check numbered delay-group properties
-				for (const [key, value] of Object.entries(step)) {
-					if (!/^\d+$/.test(key)) continue
-					const actions = Array.isArray(value) ? value : value?.actions
-					if (!Array.isArray(actions)) continue
-					for (const action of actions) {
-						const actionId = action?.actionId
-						if (isInternalId(actionId)) continue // internal references are handled above, not validated here
-						if (!validActionIds.has(actionId)) {
-							hasInvalidAction = true
+				validateChildren(feedback, depth)
+			}
+
+			const validateActionEntry = (action: any, depth: number): void => {
+				const actionId = action?.actionId
+				// internal references are handled by the filtering above, not validated here
+				if (!isInternalId(actionId)) {
+					if (!validActionIds.has(actionId)) {
+						hasInvalidAction = true
+					} else if (hasUnknownOptionKeys(actionsManager.getDefinition(actionId), action?.options)) {
+						hasInvalidActionOptionKeys = true
+					}
+				}
+				validateChildren(action, depth)
+			}
+
+			/** Validate the child groups of a building-block entry, dispatching each child by its shape */
+			const validateChildren = (entry: any, depth: number): void => {
+				if (depth > MAX_PRESET_NESTING_DEPTH) return
+				if (!entry || typeof entry !== 'object') return
+				if (!entry.children || typeof entry.children !== 'object') return
+				for (const childEntries of Object.values(entry.children)) {
+					if (!Array.isArray(childEntries)) continue
+					for (const child of childEntries) {
+						// Child groups hold feedbacks (eg condition groups) or actions; dispatch by shape
+						if (child && typeof child === 'object' && 'feedbackId' in child) {
+							validateFeedbackEntry(child, depth + 1)
 						} else {
-							const def = actionsManager.getDefinition(actionId)
-							if (def && action.options && typeof action.options === 'object') {
-								const validKeys = new Set(def.options.map((f) => f.id))
-								for (const optKey of Object.keys(action.options)) {
-									if (!validKeys.has(optKey)) {
-										hasInvalidActionOptionKeys = true
-										break
-									}
-								}
-							}
+							validateActionEntry(child, depth + 1)
 						}
 					}
 				}
 			}
+
+			// Validate the sanitised preset, so the children of dropped internal entries are not validated
+			for (const feedback of sanitisedPreset.feedbacks) {
+				validateFeedbackEntry(feedback, 0)
+			}
+
+			for (const step of sanitisedPreset.steps) {
+				if (!step || typeof step !== 'object') continue
+				for (const [key, value] of Object.entries(step)) {
+					let actions: unknown
+					if (key === 'down' || key === 'up' || key === 'rotate_left' || key === 'rotate_right') {
+						actions = value
+					} else if (/^\d+$/.test(key)) {
+						// Numbered delay-group properties
+						actions = Array.isArray(value) ? value : value?.actions
+					} else {
+						continue
+					}
+					if (!Array.isArray(actions)) continue
+					for (const action of actions) {
+						validateActionEntry(action, 0)
+					}
+				}
+			}
+
+			if (hasInvalidFeedback) presetsWithInvalidFeedbackIds.push(presetName)
+			if (hasInvalidFeedbackOptionKeys) presetsWithInvalidFeedbackOptionKeys.push(presetName)
 			if (hasInvalidAction) presetsWithInvalidActionIds.push(presetName)
 			if (hasInvalidActionOptionKeys) presetsWithInvalidActionOptionKeys.push(presetName)
 


### PR DESCRIPTION
a terrible example I am using to stress the import:

```
const presets: CompanionPresetDefinitions<DeviceSchema> = {
		abc: {
			type: 'simple',
			name: 'One',
			style: {
				color: combineRgb(255, 255, 255),
				bgcolor: 0,
				text: `${Date.now()}`,
				// textExpression: true,
				size: 'auto',
				// show_topbar: 'false',
			},
			feedbacks: [
				{
					feedbackId: 'test1',
					options: {
						state: false,
					},
					headline: 'not real',
					style: {
						color: combineRgb(0, 0, 0),
						bgcolor: thing ? combineRgb(255, 0, 0) : combineRgb(0, 255, 0),
					},
				},
				{
					feedbackId: 'internal:logicOperator',
					options: {
						operation: 'and',
					},
					headline: 'here!',
					children: {
						default: [
							{
								feedbackId: 'test1',
								options: {
									state: false,
								},
								headline: 'not real',
							},
						],
					},
					style: {
						color: combineRgb(0, 0, 0),
						bgcolor: thing ? combineRgb(255, 0, 0) : combineRgb(0, 255, 0),
					},
				},
			],
			steps: [
				{
					name: 'test abc',
					down: [
						{
							headline: 'test 123',
							actionId: 'test1',
							options: {},
						},

						{
							actionId: 'internal:logicIf',
							options: {},
							children: {
								condition: [
									{
										feedbackId: 'internal:checkExpression',
										options: {
											expression: 'true',
										},
									},
								],
								actions: [
									{
										actionId: 'internal:wait',
										options: {
											time: { isExpression: true, value: '1000 * 10' },
										},
									},
								],
							},
						},
					],
					up: [],
					2000: {
						options: {
							runWhileHeld: true,
						},
						actions: [
							{
								actionId: 'test1',
								options: {},
							},
							{
								actionId: 'internal:wait',
								options: {
									time: { isExpression: true, value: '1000 * 10' },
								},
							},
						],
					},
				},
			],
		},
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal preset building blocks (`internal:logicIf`, `internal:logicWhile`, `internal:actionGroup`, `internal:logicOperator`) for enhanced preset composition.
  * Introduced API version-gating to control access to internal preset features.

* **Tests**
  * Added comprehensive test coverage for internal action/feedback references and version compatibility validation.

* **Chores**
  * Enhanced preset type system to support internal building-block entries and nested feedback structures.
  * Added validation preventing modules from using the reserved `internal:` prefix for custom actions and feedbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->